### PR TITLE
Convert axis options from arrays to objects (#6773)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,9 +43,9 @@ var myChart = new Chart(ctx, {
     },
     options: {
         scales: {
-            yAxes: [{
+            y: {
                 beginAtZero: true
-            }]
+            }
         }
     }
 });

--- a/docs/axes/cartesian/README.md
+++ b/docs/axes/cartesian/README.md
@@ -38,7 +38,8 @@ The following options are common to all cartesian axes but do not apply to other
 | `padding` | `number` | `0` | Padding between the tick label and the axis. When set on a vertical axis, this applies in the horizontal (X) direction. When set on a horizontal axis, this applies in the vertical (Y) direction.
 
 ### Axis ID
-The properties `dataset.xAxisID` or `dataset.yAxisID` have to match the scale properties `scales.xAxes.id` or `scales.yAxes.id`. This is especially needed if multi-axes charts are used.
+
+The properties `dataset.xAxisID` or `dataset.yAxisID` have to match to `scales` property. This is especially needed if multi-axes charts are used.
 
 ```javascript
 var myChart = new Chart(ctx, {
@@ -54,11 +55,10 @@ var myChart = new Chart(ctx, {
     },
     options: {
         scales: {
-            yAxes: [{
-                id: 'first-y-axis',
+            'first-y-axis': {
                 type: 'linear'
-            }, {
-                id: 'second-y-axis',
+            },
+            'second-y-axis': {
                 type: 'linear'
             }]
         }
@@ -93,12 +93,11 @@ var myChart = new Chart(ctx, {
     },
     options: {
         scales: {
-            yAxes: [{
-                id: 'left-y-axis',
+            'left-y-axis': {
                 type: 'linear',
                 position: 'left'
-            }, {
-                id: 'right-y-axis',
+            },
+            'right-y-axis': {
                 type: 'linear',
                 position: 'right'
             }]

--- a/docs/axes/cartesian/category.md
+++ b/docs/axes/cartesian/category.md
@@ -25,10 +25,10 @@ let chart = new Chart(ctx, {
     data: ...
     options: {
         scales: {
-            xAxes: [{
+            x: {
                 type: 'category',
                 labels: ['January', 'February', 'March', 'April', 'May', 'June']
-            }]
+            }
         }
     }
 });
@@ -58,9 +58,9 @@ let chart = new Chart(ctx, {
     },
     options: {
         scales: {
-            xAxes: [{
+            x: {
                 min: 'March'
-            }]
+            }
         }
     }
 });

--- a/docs/axes/cartesian/linear.md
+++ b/docs/axes/cartesian/linear.md
@@ -45,10 +45,10 @@ let chart = new Chart(ctx, {
     },
     options: {
         scales: {
-            yAxes: [{
+            y: {
                 suggestedMin: 50,
                 suggestedMax: 100
-            }]
+            }
         }
     }
 });
@@ -65,13 +65,13 @@ This example sets up a chart with a y axis that creates ticks at `0, 0.5, 1, 1.5
 ```javascript
 let options = {
     scales: {
-        yAxes: [{
+        y: {
             max: 5,
             min: 0,
             ticks: {
                 stepSize: 0.5
             }
-        }]
+        }
     }
 };
 ```

--- a/docs/axes/cartesian/time.md
+++ b/docs/axes/cartesian/time.md
@@ -67,18 +67,19 @@ var chart = new Chart(ctx, {
     data: data,
     options: {
         scales: {
-            xAxes: [{
+            x: {
                 type: 'time',
                 time: {
                     unit: 'month'
                 }
-            }]
+            }
         }
     }
 });
 ```
 
 ### Display Formats
+
 The following display formats are used to configure how different time units are formed into strings for the axis tick marks. See [Moment.js](https://momentjs.com/docs/#/displaying/format/) for the allowable format strings.
 
 Name | Default | Example
@@ -101,14 +102,14 @@ var chart = new Chart(ctx, {
     data: data,
     options: {
         scales: {
-            xAxes: [{
+            x: {
                 type: 'time',
                 time: {
                     displayFormats: {
                         quarter: 'MMM YYYY'
                     }
                 }
-            }]
+            }
         }
     }
 });
@@ -127,10 +128,10 @@ var chart = new Chart(ctx, {
     data: data,
     options: {
         scales: {
-            xAxes: [{
+            x: {
                 type: 'time',
                 distribution: 'series'
-            }]
+            }
         }
     }
 });

--- a/docs/axes/labelling.md
+++ b/docs/axes/labelling.md
@@ -31,14 +31,14 @@ var chart = new Chart(ctx, {
     data: data,
     options: {
         scales: {
-            yAxes: [{
+            y: {
                 ticks: {
                     // Include a dollar sign in the ticks
                     callback: function(value, index, values) {
                         return '$' + value;
                     }
                 }
-            }]
+            }
         }
     }
 });

--- a/docs/charts/bar.md
+++ b/docs/charts/bar.md
@@ -41,9 +41,9 @@ A bar chart provides a way of showing data values represented as vertical bars. 
     },
     "options": {
         "scales": {
-            "yAxes": [{
+            "y": {
                 "beginAtZero": true
-            }]
+            }
         }
     }
 }
@@ -160,7 +160,9 @@ data: {
     }]
 };
 ```
+
 ### barThickness
+
 If this value is a number, it is applied to the width of each bar, in pixels. When this is enforced, `barPercentage` and `categoryPercentage` are ignored.
 
 If set to `'flex'`, the base sample widths are calculated automatically based on the previous and following samples so that they take the full available widths without overlap. Then, bars are sized using `barPercentage` and `categoryPercentage`. There is no gap when the percentage options are 1. This mode generates bars with different widths when data are not evenly spaced.
@@ -168,6 +170,7 @@ If set to `'flex'`, the base sample widths are calculated automatically based on
 If not set (default), the base sample widths are calculated using the smallest interval that prevents bar overlapping, and bars are sized using `barPercentage` and `categoryPercentage`. This mode always generates bars equally sized.
 
 ## Scale Configuration
+
 The bar chart sets unique default values for the following configuration from the associated `scale` options:
 
 | Name | Type | Default | Description
@@ -180,16 +183,17 @@ The bar chart sets unique default values for the following configuration from th
 ```javascript
 options = {
     scales: {
-        xAxes: [{
+        x: {
             gridLines: {
                 offsetGridLines: true
             }
-        }]
+        }
     }
 };
 ```
 
 ### offsetGridLines
+
 If true, the bars for a particular data point fall between the grid lines. The grid line will move to the left by one half of the tick interval, which is the space between the grid lines. If false, the grid line will go right down the middle of the bars. This is set to true for a category scale in a bar chart while false for other scales or chart types by default.
 
 ## Default Options
@@ -249,12 +253,12 @@ var stackedBar = new Chart(ctx, {
     data: data,
     options: {
         scales: {
-            xAxes: [{
+            x: {
                 stacked: true
-            }],
-            yAxes: [{
+            },
+            y: {
                 stacked: true
-            }]
+            }
         }
     }
 });
@@ -267,6 +271,7 @@ The following dataset properties are specific to stacked bar charts.
 | `stack` | `string` | The ID of the group to which this dataset belongs to (when stacked, each group will be a separate stack).
 
 ## Horizontal Bar Chart
+
 A horizontal bar chart is a variation on a vertical bar chart. It is sometimes used to show trend data, and the comparison of multiple data sets side by side.
 {% chartjs %}
 {
@@ -300,9 +305,9 @@ A horizontal bar chart is a variation on a vertical bar chart. It is sometimes u
     },
     "options": {
         "scales": {
-            "xAxes": [{
+            "x": {
                 "beginAtZero": true
-            }]
+            }
         }
     }
 }

--- a/docs/charts/line.md
+++ b/docs/charts/line.md
@@ -211,9 +211,9 @@ var stackedLine = new Chart(ctx, {
     data: data,
     options: {
         scales: {
-            yAxes: [{
+            y: {
                 stacked: true
-            }]
+            }
         }
     }
 });

--- a/docs/charts/mixed.md
+++ b/docs/charts/mixed.md
@@ -61,9 +61,9 @@ At this point we have a chart rendering how we'd like. It's important to note th
     },
     "options": {
         "scales": {
-            "yAxes": [{
+            "y": {
                 "beginAtZero": true
-            }]
+            }
         }
     }
 }

--- a/docs/charts/scatter.md
+++ b/docs/charts/scatter.md
@@ -22,10 +22,10 @@ var scatterChart = new Chart(ctx, {
     },
     options: {
         scales: {
-            xAxes: [{
+            x: {
                 type: 'linear',
                 position: 'bottom'
-            }]
+            }
         }
     }
 });

--- a/docs/developers/axes.md
+++ b/docs/developers/axes.md
@@ -24,9 +24,9 @@ var lineChart = new Chart(ctx, {
     type: 'line',
     options: {
         scales: {
-            yAxes: [{
+            y: {
                 type: 'myScale' // this is the same key that was passed to the registerScaleType function
-            }]
+            }
         }
     }
 });

--- a/docs/developers/updates.md
+++ b/docs/developers/updates.md
@@ -45,12 +45,12 @@ function updateConfigAsNewObject(chart) {
             text: 'Chart.js'
         },
         scales: {
-            xAxes: [{
+            x: {
                 display: true
-            }],
-            yAxes: [{
+            },
+            y: {
                 display: true
-            }]
+            }
         }
     };
     chart.update();
@@ -64,30 +64,29 @@ Variables referencing any one from `chart.scales` would be lost after updating s
 
 ```javascript
 function updateScales(chart) {
-    var xScale = chart.scales['x-axis-0'];
-    var yScale = chart.scales['y-axis-0'];
+    var xScale = chart.scales.x;
+    var yScale = chart.scales.y;
     chart.options.scales = {
-        xAxes: [{
-            id: 'newId',
+        newId: {
             display: true
-        }],
-        yAxes: [{
+        },
+        y: {
             display: true,
             type: 'logarithmic'
-        }]
+        }
     };
     chart.update();
     // need to update the reference
-    xScale = chart.scales['newId'];
-    yScale = chart.scales['y-axis-0'];
+    xScale = chart.scales.newId;
+    yScale = chart.scales.y;
 }
 ```
 
-You can also update a specific scale either by specifying its index or id.
+You can also update a specific scale either by its id.
 
 ```javascript
 function updateScale(chart) {
-    chart.options.scales.yAxes[0] = {
+    chart.options.scales.y = {
         type: 'logarithmic'
     };
     chart.update();

--- a/docs/getting-started/usage.md
+++ b/docs/getting-started/usage.md
@@ -53,9 +53,9 @@ var myChart = new Chart(ctx, {
     },
     options: {
         scales: {
-            yAxes: [{
+            y: {
                 beginAtZero: true
-            }]
+            }
         }
     }
 });

--- a/docs/getting-started/v3-migration.md
+++ b/docs/getting-started/v3-migration.md
@@ -33,20 +33,21 @@ Chart.js 3.0 introduces a number of breaking changes. Chart.js 2.0 was released 
 ### Options
 
 * The dataset option `tension` was renamed to `lineTension`
+* `scales.[x/y]Axes` arrays were removed. Scales are now configured directly to `options.scales` object with the object key being the scale Id.
 * `scales.[x/y]Axes.barPercentage` was moved to dataset option `barPercentage`
 * `scales.[x/y]Axes.barThickness` was moved to dataset option `barThickness`
 * `scales.[x/y]Axes.categoryPercentage` was moved to dataset option `categoryPercentage`
 * `scales.[x/y]Axes.minBarLength` was moved to dataset option `minBarLength`
 * `scales.[x/y]Axes.maxBarThickness` was moved to dataset option `maxBarThickness`
-* `scales.[x/y]Axes.ticks.beginAtZero` was renamed to `scales.[x/y]Axes.beginAtZero`
-* `scales.[x/y]Axes.ticks.max` was renamed to `scales.[x/y]Axes.max`
-* `scales.[x/y]Axes.ticks.min` was renamed to `scales.[x/y]Axes.min`
-* `scales.[x/y]Axes.ticks.reverse` was renamed to `scales.[x/y]Axes.reverse`
-* `scales.[x/y]Axes.ticks.suggestedMax` was renamed to `scales.[x/y]Axes.suggestedMax`
-* `scales.[x/y]Axes.ticks.suggestedMin` was renamed to `scales.[x/y]Axes.suggestedMin`
-* `scales.[x/y]Axes.time.format` was renamed to `scales.[x/y]Axes.time.parser`
-* `scales.[x/y]Axes.time.max` was renamed to `scales.[x/y]Axes.max`
-* `scales.[x/y]Axes.time.min` was renamed to `scales.[x/y]Axes.min`
+* `scales.[x/y]Axes.ticks.beginAtZero` was renamed to `scales[id].beginAtZero`
+* `scales.[x/y]Axes.ticks.max` was renamed to `scales[id].max`
+* `scales.[x/y]Axes.ticks.min` was renamed to `scales[id].min`
+* `scales.[x/y]Axes.ticks.reverse` was renamed to `scales[id].reverse`
+* `scales.[x/y]Axes.ticks.suggestedMax` was renamed to `scales[id].suggestedMax`
+* `scales.[x/y]Axes.ticks.suggestedMin` was renamed to `scales[id].suggestedMin`
+* `scales.[x/y]Axes.time.format` was renamed to `scales[id].time.parser`
+* `scales.[x/y]Axes.time.max` was renamed to `scales[id].max`
+* `scales.[x/y]Axes.time.min` was renamed to `scales[id].min`
 
 ## Developer migration
 

--- a/samples/charts/area/line-boundaries.html
+++ b/samples/charts/area/line-boundaries.html
@@ -59,12 +59,12 @@
 				}
 			},
 			scales: {
-				xAxes: [{
+				x: {
 					ticks: {
 						autoSkip: false,
 						maxRotation: 0
 					}
-				}]
+				}
 			}
 		};
 

--- a/samples/charts/area/line-datasets.html
+++ b/samples/charts/area/line-datasets.html
@@ -114,9 +114,9 @@
 				}
 			},
 			scales: {
-				yAxes: [{
-					stacked: true
-				}]
+				y: {
+					stacked: true,
+				}
 			},
 			plugins: {
 				filler: {

--- a/samples/charts/area/line-stacked.html
+++ b/samples/charts/area/line-stacked.html
@@ -98,19 +98,19 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						stacked: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/bar/multi-axis.html
+++ b/samples/charts/bar/multi-axis.html
@@ -33,7 +33,7 @@
 					window.chartColors.purple,
 					window.chartColors.red
 				],
-				yAxisID: 'y-axis-1',
+				yAxisID: 'y',
 				data: [
 					randomScalingFactor(),
 					randomScalingFactor(),
@@ -46,7 +46,7 @@
 			}, {
 				label: 'Dataset 2',
 				backgroundColor: window.chartColors.grey,
-				yAxisID: 'y-axis-2',
+				yAxisID: 'y1',
 				data: [
 					randomScalingFactor(),
 					randomScalingFactor(),
@@ -75,20 +75,19 @@
 						intersect: true
 					},
 					scales: {
-						yAxes: [{
-							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
+						y: {
+							type: 'linear',
 							display: true,
 							position: 'left',
-							id: 'y-axis-1',
-						}, {
-							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
+						},
+						y1: {
+							type: 'linear',
 							display: true,
 							position: 'right',
-							id: 'y-axis-2',
 							gridLines: {
 								drawOnChartArea: false
 							}
-						}],
+						},
 					}
 				}
 			});

--- a/samples/charts/bar/stacked-group.html
+++ b/samples/charts/bar/stacked-group.html
@@ -80,12 +80,12 @@
 					},
 					responsive: true,
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true,
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});

--- a/samples/charts/bar/stacked.html
+++ b/samples/charts/bar/stacked.html
@@ -77,12 +77,12 @@
 					},
 					responsive: true,
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true,
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});

--- a/samples/charts/line/basic.html
+++ b/samples/charts/line/basic.html
@@ -76,20 +76,20 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/line/interpolation-modes.html
+++ b/samples/charts/line/interpolation-modes.html
@@ -64,21 +64,21 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						},
 						suggestedMin: -10,
-						suggestedMax: 200,
-					}]
+						suggestedMax: 200
+					}
 				}
 			}
 		};

--- a/samples/charts/line/line-styles.html
+++ b/samples/charts/line/line-styles.html
@@ -83,20 +83,20 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/line/multi-axis.html
+++ b/samples/charts/line/multi-axis.html
@@ -36,7 +36,7 @@
 					randomScalingFactor(),
 					randomScalingFactor()
 				],
-				yAxisID: 'y-axis-1',
+				yAxisID: 'y',
 			}, {
 				label: 'My Second dataset',
 				borderColor: window.chartColors.blue,
@@ -51,7 +51,7 @@
 					randomScalingFactor(),
 					randomScalingFactor()
 				],
-				yAxisID: 'y-axis-2'
+				yAxisID: 'y1'
 			}]
 		};
 
@@ -69,22 +69,21 @@
 						text: 'Chart.js Line Chart - Multi Axis'
 					},
 					scales: {
-						yAxes: [{
+						y: {
 							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 							display: true,
 							position: 'left',
-							id: 'y-axis-1',
-						}, {
+						},
+						y1: {
 							type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 							display: true,
 							position: 'right',
-							id: 'y-axis-2',
 
 							// grid line settings
 							gridLines: {
 								drawOnChartArea: false, // only want the grid lines for one axis to show up
 							},
-						}],
+						},
 					}
 				}
 			});

--- a/samples/charts/line/point-sizes.html
+++ b/samples/charts/line/point-sizes.html
@@ -97,20 +97,20 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				},
 				title: {
 					display: true,

--- a/samples/charts/line/skip-points.html
+++ b/samples/charts/line/skip-points.html
@@ -67,20 +67,20 @@
 					mode: 'index'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						},
-					}]
+					}
 				}
 			}
 		};

--- a/samples/charts/scatter/multi-axis.html
+++ b/samples/charts/scatter/multi-axis.html
@@ -24,8 +24,8 @@
 	var scatterChartData = {
 		datasets: [{
 			label: 'My First dataset',
-			xAxisID: 'x-axis-1',
-			yAxisID: 'y-axis-1',
+			xAxisID: 'x',
+			yAxisID: 'y',
 			borderColor: window.chartColors.red,
 			backgroundColor: color(window.chartColors.red).alpha(0.2).rgbString(),
 			data: [{
@@ -52,8 +52,8 @@
 			}]
 		}, {
 			label: 'My Second dataset',
-			xAxisID: 'x-axis-1',
-			yAxisID: 'y-axis-2',
+			xAxisID: 'x',
+			yAxisID: 'y2',
 			borderColor: window.chartColors.blue,
 			backgroundColor: color(window.chartColors.blue).alpha(0.2).rgbString(),
 			data: [{
@@ -95,26 +95,25 @@
 					text: 'Chart.js Scatter Chart - Multi Axis'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						position: 'bottom',
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 						display: true,
-						position: 'left',
-						id: 'y-axis-1',
-					}, {
+						position: 'left'
+					},
+					y2: {
 						type: 'linear', // only linear but allow scale type registration. This allows extensions to exist solely for log scale for instance
 						display: true,
 						position: 'right',
 						reverse: true,
-						id: 'y-axis-2',
 
 						// grid line settings
 						gridLines: {
 							drawOnChartArea: false, // only want the grid lines for one axis to show up
-						},
-					}],
+						}
+					}
 				}
 			}
 		});

--- a/samples/legend/callbacks.html
+++ b/samples/legend/callbacks.html
@@ -99,20 +99,20 @@
 					text: 'Chart.js Line Chart'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/legend/point-style.html
+++ b/samples/legend/point-style.html
@@ -68,20 +68,20 @@
 						}
 					},
 					scales: {
-						xAxes: [{
+						x: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Month'
 							}
-						}],
-						yAxes: [{
+						},
+						y: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Value'
 							}
-						}]
+						}
 					},
 					title: {
 						display: true,

--- a/samples/legend/positioning.html
+++ b/samples/legend/positioning.html
@@ -69,20 +69,20 @@
 						position: legendPosition,
 					},
 					scales: {
-						xAxes: [{
+						x: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Month'
 							}
-						}],
-						yAxes: [{
+						},
+						y: {
 							display: true,
 							scaleLabel: {
 								display: true,
 								labelString: 'Value'
 							}
-						}]
+						}
 					},
 					title: {
 						display: true,

--- a/samples/scales/filtering-labels.html
+++ b/samples/scales/filtering-labels.html
@@ -64,7 +64,7 @@
 					text: 'Chart.js Line Chart - X-Axis Filter'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						ticks: {
 							callback: function(dataLabel, index) {
@@ -72,11 +72,11 @@
 								return index % 2 === 0 ? dataLabel : '';
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						beginAtZero: false
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/gridlines-display.html
+++ b/samples/scales/gridlines-display.html
@@ -55,17 +55,17 @@
 						text: title
 					},
 					scales: {
-						xAxes: [{
+						x: {
 							gridLines: gridlines
-						}],
-						yAxes: [{
+						},
+						y: {
 							gridLines: gridlines,
 							min: 0,
 							max: 100,
 							ticks: {
 								stepSize: 10
 							}
-						}]
+						}
 					}
 				}
 			};

--- a/samples/scales/gridlines-style.html
+++ b/samples/scales/gridlines-style.html
@@ -44,7 +44,7 @@
 					text: 'Grid Line Settings'
 				},
 				scales: {
-					yAxes: [{
+					y: {
 						gridLines: {
 							drawBorder: false,
 							color: ['pink', 'red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'purple']
@@ -54,7 +54,7 @@
 						ticks: {
 							stepSize: 10
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/linear/min-max-suggested.html
+++ b/samples/scales/linear/min-max-suggested.html
@@ -44,13 +44,13 @@
 					text: 'Min and Max Settings'
 				},
 				scales: {
-					yAxes: [{
+					y: {
 						// the data minimum used for determining the ticks is Math.min(dataMin, suggestedMin)
 						suggestedMin: 10,
 
 						// the data maximum used for determining the ticks is Math.max(dataMax, suggestedMax)
 						suggestedMax: 50
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/linear/min-max.html
+++ b/samples/scales/linear/min-max.html
@@ -44,10 +44,10 @@
 					text: 'Min and Max Settings'
 				},
 				scales: {
-					yAxes: [{
+					y: {
 						min: 10,
 						max: 50
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/linear/step-size.html
+++ b/samples/scales/linear/step-size.html
@@ -81,14 +81,14 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
@@ -100,7 +100,7 @@
 							// forces step size to be 5 units
 							stepSize: 5
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/logarithmic/line.html
+++ b/samples/scales/logarithmic/line.html
@@ -65,13 +65,13 @@
 				text: 'Chart.js Line Chart - Logarithmic'
 			},
 			scales: {
-				xAxes: [{
+				x: {
 					display: true,
-				}],
-				yAxes: [{
+				},
+				y: {
 					display: true,
 					type: 'logarithmic',
-				}]
+				}
 			}
 		}
 	};

--- a/samples/scales/logarithmic/scatter.html
+++ b/samples/scales/logarithmic/scatter.html
@@ -133,7 +133,7 @@
 					text: 'Chart.js Scatter Chart - Logarithmic X-Axis'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'logarithmic',
 						position: 'bottom',
 						ticks: {
@@ -149,8 +149,8 @@
 							labelString: 'Frequency',
 							display: true,
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						ticks: {
 							userCallback: function(tick) {
@@ -161,7 +161,7 @@
 							labelString: 'Voltage',
 							display: true
 						}
-					}]
+					}
 				}
 			}
 		});

--- a/samples/scales/non-numeric-y.html
+++ b/samples/scales/non-numeric-y.html
@@ -39,14 +39,14 @@
 					text: 'Chart with Non Numeric Y Axis'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'category',
 						position: 'left',
 						display: true,
@@ -55,7 +55,7 @@
 							labelString: 'Request State'
 						},
 						reverse: true
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/time/combo.html
+++ b/samples/scales/time/combo.html
@@ -73,14 +73,14 @@
 					text: 'Chart.js Combo Time Scale'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						display: true,
 						offset: true,
 						time: {
 							unit: 'day'
 						}
-					}],
+					},
 				},
 			}
 		};

--- a/samples/scales/time/financial.html
+++ b/samples/scales/time/financial.html
@@ -115,7 +115,7 @@
 					duration: 0
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						distribution: 'series',
 						offset: true,
@@ -156,8 +156,9 @@
 								lastMajor = currMajor;
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
+						type: 'linear',
 						gridLines: {
 							drawBorder: false
 						},
@@ -165,7 +166,7 @@
 							display: true,
 							labelString: 'Closing price ($)'
 						}
-					}]
+					}
 				},
 				tooltips: {
 					intersect: false,

--- a/samples/scales/time/line-point-data.html
+++ b/samples/scales/time/line-point-data.html
@@ -82,7 +82,7 @@
 					text: 'Chart.js Time Point Data'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						display: true,
 						scaleLabel: {
@@ -95,14 +95,14 @@
 								fontColor: '#FF0000'
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							display: true,
 							labelString: 'value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/samples/scales/time/line.html
+++ b/samples/scales/time/line.html
@@ -103,7 +103,7 @@
 					text: 'Chart.js Time Scale'
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						time: {
 							parser: timeFormat,
@@ -114,13 +114,13 @@
 							display: true,
 							labelString: 'Date'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						scaleLabel: {
 							display: true,
 							labelString: 'value'
 						}
-					}]
+					}
 				},
 			}
 		};

--- a/samples/scales/toggle-scale-type.html
+++ b/samples/scales/toggle-scale-type.html
@@ -67,13 +67,13 @@
 					text: 'Chart.js Line Chart - ' + type
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						type: type
-					}]
+					}
 				}
 			}
 		};
@@ -86,7 +86,7 @@
 		document.getElementById('toggleScale').addEventListener('click', function() {
 			type = type === 'linear' ? 'logarithmic' : 'linear';
 			window.myLine.options.title.text = 'Chart.js Line Chart - ' + type;
-			window.myLine.options.scales.yAxes[0] = {
+			window.myLine.options.scales.y = {
 				display: true,
 				type: type
 			};

--- a/samples/tooltips/callbacks.html
+++ b/samples/tooltips/callbacks.html
@@ -79,20 +79,20 @@
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: true,
 						scaleLabel: {
 							show: true,
 							labelString: 'Month'
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: true,
 						scaleLabel: {
 							show: true,
 							labelString: 'Value'
 						}
-					}]
+					}
 				}
 			}
 		};

--- a/src/controllers/controller.bar.js
+++ b/src/controllers/controller.bar.js
@@ -13,17 +13,16 @@ defaults._set('bar', {
 	},
 
 	scales: {
-		xAxes: [{
+		x: {
 			type: 'category',
 			offset: true,
 			gridLines: {
 				offsetGridLines: true
 			}
-		}],
-
-		yAxes: [{
-			type: 'linear'
-		}]
+		},
+		y: {
+			type: 'linear',
+		}
 	}
 });
 
@@ -221,13 +220,13 @@ module.exports = DatasetController.extend({
 	_parseObjectData: function(meta, data, start, count) {
 		const iScale = meta.iScale;
 		const vScale = meta.vScale;
-		const vProp = vScale._getAxis();
+		const vProp = vScale.axis;
 		const parsed = [];
 		let i, ilen, item, obj, value;
 		for (i = start, ilen = start + count; i < ilen; ++i) {
 			obj = data[i];
 			item = {};
-			item[iScale.id] = iScale._parseObject(obj, iScale._getAxis(), i);
+			item[iScale.id] = iScale._parseObject(obj, iScale.axis, i);
 			value = obj[vProp];
 			if (helpers.isArray(value)) {
 				parseFloatBar(value, item, vScale, i);

--- a/src/controllers/controller.bubble.js
+++ b/src/controllers/controller.bubble.js
@@ -10,16 +10,14 @@ var resolve = helpers.options.resolve;
 
 defaults._set('bubble', {
 	scales: {
-		xAxes: [{
-			type: 'linear', // bubble should probably use a linear scale by default
-			position: 'bottom',
-			id: 'x-axis-0' // need an ID so datasets can reference the scale
-		}],
-		yAxes: [{
+		x: {
 			type: 'linear',
-			position: 'left',
-			id: 'y-axis-0'
-		}]
+			position: 'bottom'
+		},
+		y: {
+			type: 'linear',
+			position: 'left'
+		}
 	},
 
 	tooltips: {

--- a/src/controllers/controller.horizontalBar.js
+++ b/src/controllers/controller.horizontalBar.js
@@ -10,19 +10,18 @@ defaults._set('horizontalBar', {
 	},
 
 	scales: {
-		xAxes: [{
+		x: {
 			type: 'linear',
 			position: 'bottom'
-		}],
-
-		yAxes: [{
+		},
+		y: {
 			type: 'category',
 			position: 'left',
 			offset: true,
 			gridLines: {
 				offsetGridLines: true
 			}
-		}]
+		}
 	},
 
 	elements: {

--- a/src/controllers/controller.line.js
+++ b/src/controllers/controller.line.js
@@ -18,14 +18,12 @@ defaults._set('line', {
 	},
 
 	scales: {
-		xAxes: [{
+		x: {
 			type: 'category',
-			id: 'x-axis-0'
-		}],
-		yAxes: [{
+		},
+		y: {
 			type: 'linear',
-			id: 'y-axis-0'
-		}]
+		},
 	}
 });
 

--- a/src/controllers/controller.polarArea.js
+++ b/src/controllers/controller.polarArea.js
@@ -8,17 +8,19 @@ var helpers = require('../helpers/index');
 var resolve = helpers.options.resolve;
 
 defaults._set('polarArea', {
-	scale: {
-		type: 'radialLinear',
-		angleLines: {
-			display: false
-		},
-		beginAtZero: true,
-		gridLines: {
-			circular: true
-		},
-		pointLabels: {
-			display: false
+	scales: {
+		r: {
+			type: 'radialLinear',
+			angleLines: {
+				display: false
+			},
+			beginAtZero: true,
+			gridLines: {
+				circular: true
+			},
+			pointLabels: {
+				display: false
+			}
 		}
 	},
 
@@ -123,14 +125,14 @@ module.exports = DatasetController.extend({
 	 * @private
 	 */
 	_getIndexScaleId: function() {
-		return this.chart.scale.id;
+		return this._cachedMeta.rAxisID;
 	},
 
 	/**
 	 * @private
 	 */
 	_getValueScaleId: function() {
-		return this.chart.scale.id;
+		return this._cachedMeta.rAxisID;
 	},
 
 	update: function(reset) {
@@ -181,7 +183,7 @@ module.exports = DatasetController.extend({
 		const dataset = me.getDataset();
 		const opts = chart.options;
 		const animationOpts = opts.animation;
-		const scale = chart.scale;
+		const scale = chart.scales.r;
 		const centerX = scale.xCenter;
 		const centerY = scale.yCenter;
 		var i;

--- a/src/controllers/controller.radar.js
+++ b/src/controllers/controller.radar.js
@@ -9,8 +9,10 @@ var valueOrDefault = helpers.valueOrDefault;
 
 defaults._set('radar', {
 	spanGaps: false,
-	scale: {
-		type: 'radialLinear'
+	scales: {
+		r: {
+			type: 'radialLinear',
+		}
 	},
 	elements: {
 		line: {
@@ -67,14 +69,14 @@ module.exports = DatasetController.extend({
 	 * @private
 	 */
 	_getIndexScaleId: function() {
-		return this.chart.scale.id;
+		return this._cachedMeta.rAxisID;
 	},
 
 	/**
 	 * @private
 	 */
 	_getValueScaleId: function() {
-		return this.chart.scale.id;
+		return this._cachedMeta.rAxisID;
 	},
 
 	/**
@@ -122,7 +124,7 @@ module.exports = DatasetController.extend({
 	updateElements: function(points, start, count, reset) {
 		const me = this;
 		const dataset = me.getDataset();
-		const scale = me.chart.scale;
+		const scale = me.chart.scales.r;
 		var i;
 
 		for (i = start; i < start + count; i++) {

--- a/src/controllers/controller.scatter.js
+++ b/src/controllers/controller.scatter.js
@@ -5,16 +5,14 @@ var defaults = require('../core/core.defaults');
 
 defaults._set('scatter', {
 	scales: {
-		xAxes: [{
-			id: 'x-axis-1',    // need an ID so datasets can reference the scale
-			type: 'linear',    // scatter should not use a category axis
+		x: {
+			type: 'linear',
 			position: 'bottom'
-		}],
-		yAxes: [{
-			id: 'y-axis-1',
+		},
+		y: {
 			type: 'linear',
 			position: 'left'
-		}]
+		}
 	},
 
 	tooltips: {

--- a/src/core/core.controller.js
+++ b/src/core/core.controller.js
@@ -35,44 +35,46 @@ defaults._set('global', {
 	responsiveAnimationDuration: 0
 });
 
-/**
- * Recursively merge the given config objects representing the `scales` option
- * by incorporating scale defaults in `xAxes` and `yAxes` array items, then
- * returns a deep copy of the result, thus doesn't alter inputs.
- */
-function mergeScaleConfig(/* config objects ... */) {
-	return helpers.merge({}, [].slice.call(arguments), {
-		merger: function(key, target, source, options) {
-			if (key === 'xAxes' || key === 'yAxes') {
-				var slen = source[key].length;
-				var i, type, scale;
+function mergeScaleConfig(config, options) {
+	options = options || {};
+	const chartDefaults = defaults[config.type] || {scales: {}};
+	const configScales = options.scales || {};
+	const firstIDs = {};
+	const scales = {};
 
-				if (!target[key]) {
-					target[key] = [];
-				}
-
-				for (i = 0; i < slen; ++i) {
-					scale = source[key][i];
-					type = valueOrDefault(scale.type, key === 'xAxes' ? 'category' : 'linear');
-
-					if (i >= target[key].length) {
-						target[key].push({});
-					}
-
-					if (!target[key][i].type || (scale.type && scale.type !== target[key][i].type)) {
-						// new/untyped scale or type changed: let's apply the new defaults
-						// then merge source scale to correctly overwrite the defaults.
-						helpers.merge(target[key][i], [scaleService.getScaleDefaults(type), scale]);
-					} else {
-						// scales type are the same
-						helpers.merge(target[key][i], scale);
-					}
-				}
-			} else {
-				helpers._merger(key, target, source, options);
-			}
-		}
+	// First figure out first scale id's per axis.
+	// Note: for now, axis is determined from first letter of scale id!
+	Object.entries(configScales).forEach(([id, scale]) => {
+		const axis = id[0];
+		firstIDs[axis] = firstIDs[axis] || id;
+		scales[id] = helpers.mergeIf({}, [scale, chartDefaults.scales[axis]]);
 	});
+
+	// Backward compatibility
+	if (options.scale) {
+		scales[options.scale.id || 'r'] = helpers.mergeIf({}, [options.scale, chartDefaults.scales.r]);
+		firstIDs.r = firstIDs.r || options.scale.id || 'r';
+	}
+
+	// Then merge dataset defaults to scale configs
+	config.data.datasets.forEach(dataset => {
+		const datasetDefaults = defaults[dataset.type || config.type] || {scales: {}};
+		Object.entries(datasetDefaults.scales || {}).forEach(([defaultID, defaultScaleOptions]) => {
+			const id = dataset[defaultID + 'AxisID'] || firstIDs[defaultID] || defaultID;
+			scales[id] = scales[id] || {};
+			helpers.mergeIf(scales[id], [
+				configScales[id],
+				defaultScaleOptions
+			]);
+		});
+	});
+
+	// apply scale defaults, if not overridden by dataset defaults
+	Object.values(scales).forEach(scale => {
+		helpers.mergeIf(scale, scaleService.getScaleDefaults(scale.type));
+	});
+
+	return scales;
 }
 
 /**
@@ -83,16 +85,7 @@ function mergeScaleConfig(/* config objects ... */) {
 function mergeConfig(/* config objects ... */) {
 	return helpers.merge({}, [].slice.call(arguments), {
 		merger: function(key, target, source, options) {
-			var tval = target[key] || {};
-			var sval = source[key];
-
-			if (key === 'scales') {
-				// scale config merging is complex. Add our own function here for that
-				target[key] = mergeScaleConfig(tval, sval);
-			} else if (key === 'scale') {
-				// used in polar area & radar charts since there is only one scale
-				target[key] = helpers.merge(tval, [scaleService.getScaleDefaults(sval.type), sval]);
-			} else {
+			if (key !== 'scales' && key !== 'scale') {
 				helpers._merger(key, target, source, options);
 			}
 		}
@@ -104,14 +97,18 @@ function initConfig(config) {
 
 	// Do NOT use mergeConfig for the data object because this method merges arrays
 	// and so would change references to labels and datasets, preventing data updates.
-	var data = config.data = config.data || {};
+	const data = config.data = config.data || {};
 	data.datasets = data.datasets || [];
 	data.labels = data.labels || [];
+
+	const scaleConfig = mergeScaleConfig(config, config.options);
 
 	config.options = mergeConfig(
 		defaults.global,
 		defaults[config.type],
 		config.options || {});
+
+	config.options.scales = scaleConfig;
 
 	return config;
 }
@@ -131,12 +128,16 @@ function updateConfig(chart) {
 		layouts.removeBox(chart, scale);
 	});
 
+	const scaleConfig = mergeScaleConfig(chart.config, newOptions);
+
 	newOptions = mergeConfig(
 		defaults.global,
 		defaults[chart.config.type],
 		newOptions);
 
 	chart.options = chart.config.options = newOptions;
+	chart.options.scales = scaleConfig;
+
 	chart._animationsDisabled = isAnimationDisabled(newOptions);
 	chart.ensureScalesHaveIDs();
 	chart.buildOrUpdateScales();
@@ -144,19 +145,6 @@ function updateConfig(chart) {
 	// Tooltip
 	chart.tooltip._options = newOptions.tooltips;
 	chart.tooltip.initialize();
-}
-
-function nextAvailableScaleId(axesOpts, prefix, index) {
-	var id;
-	var hasId = function(obj) {
-		return obj.id === id;
-	};
-
-	do {
-		id = prefix + index++;
-	} while (helpers.findIndex(axesOpts, hasId) >= 0);
-
-	return id;
 }
 
 function positionIsHorizontal(position) {
@@ -310,16 +298,8 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 		var scalesOptions = options.scales || {};
 		var scaleOptions = options.scale;
 
-		helpers.each(scalesOptions.xAxes, function(xAxisOptions, index) {
-			if (!xAxisOptions.id) {
-				xAxisOptions.id = nextAvailableScaleId(scalesOptions.xAxes, 'x-axis-', index);
-			}
-		});
-
-		helpers.each(scalesOptions.yAxes, function(yAxisOptions, index) {
-			if (!yAxisOptions.id) {
-				yAxisOptions.id = nextAvailableScaleId(scalesOptions.yAxes, 'y-axis-', index);
-			}
+		helpers.each(scalesOptions, function(axisOptions, axisID) {
+			axisOptions.id = axisID;
 		});
 
 		if (scaleOptions) {
@@ -342,22 +322,18 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 
 		if (options.scales) {
 			items = items.concat(
-				(options.scales.xAxes || []).map(function(xAxisOptions) {
-					return {options: xAxisOptions, dtype: 'category', dposition: 'bottom'};
-				}),
-				(options.scales.yAxes || []).map(function(yAxisOptions) {
-					return {options: yAxisOptions, dtype: 'linear', dposition: 'left'};
+				Object.entries(options.scales).map(function(entry) {
+					var axisID = entry[0];
+					var axisOptions = entry[1];
+					var isRadial = axisID.charAt(0).toLowerCase === 'r';
+					var isHorizontal = axisID.charAt(0).toLowerCase() === 'x';
+					return {
+						options: axisOptions,
+						dposition: isRadial ? 'chartArea' : isHorizontal ? 'bottom' : 'left',
+						dtype: isRadial ? 'radialLinear' : isHorizontal ? 'category' : 'linear'
+					};
 				})
 			);
-		}
-
-		if (options.scale) {
-			items.push({
-				options: options.scale,
-				dtype: 'radialLinear',
-				isDefault: true,
-				dposition: 'chartArea'
-			});
 		}
 
 		helpers.each(items, function(item) {
@@ -390,6 +366,8 @@ helpers.extend(Chart.prototype, /** @lends Chart */ {
 				});
 				scales[scale.id] = scale;
 			}
+
+			scale.axis = scale.options.position === 'chartArea' ? 'r' : scale.isHorizontal() ? 'x' : 'y';
 
 			// parse min/max value, so we can properly determine min/max for other scales
 			scale._userMin = scale._parse(scale.options.min);

--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -175,15 +175,6 @@ function getStackKey(indexScale, valueScale, meta) {
 	return indexScale.id + '.' + valueScale.id + '.' + meta.stack + '.' + meta.type;
 }
 
-function getFirstScaleId(chart, axis) {
-	var scalesOpts = chart.options.scales;
-	var scale = chart.options.scale;
-	var scaleId = scale && scale.id;
-	var prop = axis + 'Axes';
-
-	return (scalesOpts && scalesOpts[prop] && scalesOpts[prop].length && scalesOpts[prop][0].id) || scaleId;
-}
-
 function getUserBounds(scale) {
 	var {min, max, minDefined, maxDefined} = scale._getUserBounds();
 	return {
@@ -228,6 +219,13 @@ function updateStacks(controller, parsed) {
 			stack[datasetIndex] = x;
 		}
 	}
+}
+
+function getFirstScaleId(chart, axis) {
+	const scales = chart.scales;
+	return Object.keys(scales).filter(key => {
+		return scales[key].axis === axis;
+	}).shift();
 }
 
 // Base class for all dataset controllers (line, bar, etc)
@@ -300,10 +298,13 @@ helpers.extend(DatasetController.prototype, {
 		const chart = me.chart;
 		const meta = me._cachedMeta;
 		const dataset = me.getDataset();
+
 		const xid = meta.xAxisID = dataset.xAxisID || getFirstScaleId(chart, 'x');
 		const yid = meta.yAxisID = dataset.yAxisID || getFirstScaleId(chart, 'y');
+		const rid = meta.rAxisID = dataset.rAxisID || getFirstScaleId(chart, 'r');
 		meta.xScale = me.getScaleForId(xid);
 		meta.yScale = me.getScaleForId(yid);
+		meta.rScale = me.getScaleForId(rid);
 		meta.iScale = me._getIndexScale();
 		meta.vScale = me._getValueScale();
 	},

--- a/src/core/core.scale.js
+++ b/src/core/core.scale.js
@@ -1389,13 +1389,6 @@ class Scale extends Element {
 	}
 
 	/**
-	 * @private
-	 */
-	_getAxis() {
-		return this.isHorizontal() ? 'x' : 'y';
-	}
-
-	/**
 	 * Returns visible dataset metas that are attached to this scale
 	 * @param {string} [type] - if specified, also filter by dataset type
 	 * @private
@@ -1403,7 +1396,7 @@ class Scale extends Element {
 	_getMatchingVisibleMetas(type) {
 		var me = this;
 		var metas = me.chart._getSortedVisibleDatasetMetas();
-		var axisID = me._getAxis() + 'AxisID';
+		var axisID = me.axis + 'AxisID';
 		var result = [];
 		var i, ilen, meta;
 

--- a/src/plugins/plugin.filler.js
+++ b/src/plugins/plugin.filler.js
@@ -428,7 +428,7 @@ module.exports = {
 					visible: chart.isDatasetVisible(i),
 					fill: decodeFill(el, i, count),
 					chart: chart,
-					scale: meta.controller.getScaleForId(meta.yAxisID) || chart.scale,
+					scale: meta.yScale || meta.rScale,
 					el: el
 				};
 			}

--- a/test/fixtures/controller.bar/backgroundColor/indexable.js
+++ b/test/fixtures/controller.bar/backgroundColor/indexable.js
@@ -38,8 +38,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/backgroundColor/scriptable.js
+++ b/test/fixtures/controller.bar/backgroundColor/scriptable.js
@@ -36,13 +36,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/backgroundColor/value.js
+++ b/test/fixtures/controller.bar/backgroundColor/value.js
@@ -24,8 +24,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/bar-thickness-absolute.json
+++ b/test/fixtures/controller.bar/bar-thickness-absolute.json
@@ -16,7 +16,7 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "offset": true,
                     "display": false,
@@ -26,11 +26,11 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-flex-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-offset.json
@@ -16,7 +16,7 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "offset": true,
                     "display": false,
@@ -26,11 +26,11 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-flex-single-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-single-reverse.json
@@ -16,9 +16,10 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
@@ -26,11 +27,11 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-flex-single.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex-single.json
@@ -16,20 +16,21 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-flex.json
+++ b/test/fixtures/controller.bar/bar-thickness-flex.json
@@ -16,20 +16,21 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-max.json
+++ b/test/fixtures/controller.bar/bar-thickness-max.json
@@ -16,20 +16,21 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-min-interval.json
+++ b/test/fixtures/controller.bar/bar-thickness-min-interval.json
@@ -15,20 +15,21 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-multiple.json
+++ b/test/fixtures/controller.bar/bar-thickness-multiple.json
@@ -25,20 +25,21 @@
                 }
             },
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-no-overlap.json
+++ b/test/fixtures/controller.bar/bar-thickness-no-overlap.json
@@ -25,20 +25,21 @@
                 }
             },
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY-MM"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-offset.json
+++ b/test/fixtures/controller.bar/bar-thickness-offset.json
@@ -25,7 +25,7 @@
                 }
             },
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "offset": true,
                     "display": false,
@@ -35,11 +35,11 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-per-dataset-stacked.json
+++ b/test/fixtures/controller.bar/bar-thickness-per-dataset-stacked.json
@@ -24,7 +24,7 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "offset": true,
                     "stacked": true,
@@ -35,12 +35,12 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "stacked": true,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-per-dataset.json
+++ b/test/fixtures/controller.bar/bar-thickness-per-dataset.json
@@ -19,7 +19,7 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "offset": true,
                     "display": false,
@@ -29,11 +29,11 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-reverse.json
+++ b/test/fixtures/controller.bar/bar-thickness-reverse.json
@@ -25,9 +25,10 @@
                 }
             },
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
@@ -35,11 +36,11 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-single-xy.json
+++ b/test/fixtures/controller.bar/bar-thickness-single-xy.json
@@ -15,20 +15,21 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-single.json
+++ b/test/fixtures/controller.bar/bar-thickness-single.json
@@ -15,9 +15,10 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
@@ -25,11 +26,11 @@
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/bar-thickness-stacked.json
+++ b/test/fixtures/controller.bar/bar-thickness-stacked.json
@@ -25,22 +25,23 @@
                 }
             },
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "time",
                     "stacked": true,
                     "display": false,
+                    "offset": false,
                     "time": {
                         "parser": "YYYY"
                     },
                     "ticks": {
                         "source": "labels"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "stacked": true,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/borderColor/indexable.js
+++ b/test/fixtures/controller.bar/borderColor/indexable.js
@@ -40,8 +40,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderColor/scriptable.js
+++ b/test/fixtures/controller.bar/borderColor/scriptable.js
@@ -38,13 +38,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderColor/value.js
+++ b/test/fixtures/controller.bar/borderColor/value.js
@@ -26,8 +26,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderSkipped/indexable.js
+++ b/test/fixtures/controller.bar/borderSkipped/indexable.js
@@ -41,8 +41,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderSkipped/scriptable.js
+++ b/test/fixtures/controller.bar/borderSkipped/scriptable.js
@@ -39,13 +39,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderSkipped/value.js
+++ b/test/fixtures/controller.bar/borderSkipped/value.js
@@ -42,8 +42,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderWidth/indexable-object.js
+++ b/test/fixtures/controller.bar/borderWidth/indexable-object.js
@@ -42,8 +42,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderWidth/indexable.js
+++ b/test/fixtures/controller.bar/borderWidth/indexable.js
@@ -40,8 +40,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderWidth/negative.js
+++ b/test/fixtures/controller.bar/borderWidth/negative.js
@@ -35,8 +35,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderWidth/object.js
+++ b/test/fixtures/controller.bar/borderWidth/object.js
@@ -28,8 +28,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderWidth/scriptable-object.js
+++ b/test/fixtures/controller.bar/borderWidth/scriptable-object.js
@@ -33,13 +33,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderWidth/scriptable.js
+++ b/test/fixtures/controller.bar/borderWidth/scriptable.js
@@ -31,13 +31,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/borderWidth/value.js
+++ b/test/fixtures/controller.bar/borderWidth/value.js
@@ -26,8 +26,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/chart-area-clip.js
+++ b/test/fixtures/controller.bar/chart-area-clip.js
@@ -28,8 +28,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false, min: -10, max: 10}]
+				x: {display: false},
+				y: {display: false, min: -10, max: 10}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/data/object.js
+++ b/test/fixtures/controller.bar/data/object.js
@@ -18,8 +18,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/floatBar/data-as-objects-horizontal.js
+++ b/test/fixtures/controller.bar/floatBar/data-as-objects-horizontal.js
@@ -18,8 +18,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{display: false, min: 0}],
-				yAxes: [{display: false, stacked: true}]
+				x: {display: false, min: 0},
+				y: {display: false, stacked: true}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/floatBar/data-as-objects.js
+++ b/test/fixtures/controller.bar/floatBar/data-as-objects.js
@@ -18,8 +18,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{display: false, stacked: true}],
-				yAxes: [{display: false, min: 0}]
+				x: {display: false, stacked: true},
+				y: {display: false, min: 0}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/floatBar/float-bar-horizontal.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar-horizontal.json
@@ -18,14 +18,14 @@
             "title": false,
             "legend": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false,
                     "min": -8,
                     "max": 12
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/floatBar/float-bar-stacked-horizontal.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar-stacked-horizontal.json
@@ -18,16 +18,16 @@
             "title": false,
             "legend": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false,
                     "stacked": true
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "stacked": true,
                     "min": -8,
                     "max": 12
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/floatBar/float-bar-stacked.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar-stacked.json
@@ -18,16 +18,16 @@
             "title": false,
             "legend": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false,
                     "stacked": true,
                     "min": -8,
                     "max": 12
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "stacked": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/floatBar/float-bar.json
+++ b/test/fixtures/controller.bar/floatBar/float-bar.json
@@ -18,14 +18,14 @@
             "title": false,
             "legend": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false,
                     "min": -8,
                     "max": 12
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/horizontal-borders.js
+++ b/test/fixtures/controller.bar/horizontal-borders.js
@@ -28,8 +28,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.bar/stacking/order-default.json
+++ b/test/fixtures/controller.bar/stacking/order-default.json
@@ -19,15 +19,15 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false,
                     "stacked": true
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "stacked": true,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bar/stacking/order-specified.json
+++ b/test/fixtures/controller.bar/stacking/order-specified.json
@@ -22,15 +22,15 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false,
                     "stacked": true
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false,
                     "stacked": true,
                     "beginAtZero": true
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.bubble/clip.js
+++ b/test/fixtures/controller.bubble/clip.js
@@ -14,15 +14,15 @@ module.exports = {
 		options: {
 			legend: false,
 			scales: {
-				xAxes: [{ticks: {display: false}}],
-				yAxes: [{
+				x: {ticks: {display: false}},
+				y: {
 					min: 8,
 					max: 25,
 					beginAtZero: true,
 					ticks: {
 						display: false
 					}
-				}]
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.bubble/point-style.json
+++ b/test/fixtures/controller.bubble/point-style.json
@@ -93,12 +93,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{
+                "x": {"display": false},
+                "y": {
                     "display": false,
                     "min": 0,
                     "max": 4
-                }]
+                }
             },
             "elements": {
                 "line": {

--- a/test/fixtures/controller.bubble/radius-data.js
+++ b/test/fixtures/controller.bubble/radius-data.js
@@ -21,8 +21,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			},
 			elements: {
 				point: {

--- a/test/fixtures/controller.bubble/radius-scriptable.js
+++ b/test/fixtures/controller.bubble/radius-scriptable.js
@@ -20,8 +20,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			},
 			elements: {
 				point: {

--- a/test/fixtures/controller.line/backgroundColor/scriptable.js
+++ b/test/fixtures/controller.line/backgroundColor/scriptable.js
@@ -41,13 +41,11 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/backgroundColor/value.js
+++ b/test/fixtures/controller.line/backgroundColor/value.js
@@ -30,8 +30,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderCapStyle/scriptable.js
+++ b/test/fixtures/controller.line/borderCapStyle/scriptable.js
@@ -47,13 +47,11 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderCapStyle/value.js
+++ b/test/fixtures/controller.line/borderCapStyle/value.js
@@ -38,8 +38,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderColor/scriptable.js
+++ b/test/fixtures/controller.line/borderColor/scriptable.js
@@ -44,13 +44,11 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderColor/value.js
+++ b/test/fixtures/controller.line/borderColor/value.js
@@ -32,8 +32,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderDash/scriptable.js
+++ b/test/fixtures/controller.line/borderDash/scriptable.js
@@ -35,13 +35,11 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderDash/value.js
+++ b/test/fixtures/controller.line/borderDash/value.js
@@ -33,8 +33,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderDashOffset/scriptable.js
+++ b/test/fixtures/controller.line/borderDashOffset/scriptable.js
@@ -39,8 +39,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderDashOffset/value.js
+++ b/test/fixtures/controller.line/borderDashOffset/value.js
@@ -35,8 +35,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderJoinStyle/scriptable.js
+++ b/test/fixtures/controller.line/borderJoinStyle/scriptable.js
@@ -47,8 +47,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderJoinStyle/value.js
+++ b/test/fixtures/controller.line/borderJoinStyle/value.js
@@ -38,8 +38,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderWidth/scriptable.js
+++ b/test/fixtures/controller.line/borderWidth/scriptable.js
@@ -42,13 +42,11 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/borderWidth/value.js
+++ b/test/fixtures/controller.line/borderWidth/value.js
@@ -33,8 +33,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/clip/default-x-max.json
+++ b/test/fixtures/controller.line/clip/default-x-max.json
@@ -16,13 +16,13 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "max": 3,
                     "ticks": {
                         "display": false
                     }
-                }],
-                "yAxes": [{"ticks": {"display": false}}]
+                },
+                "y": {"ticks": {"display": false}}
             },
             "layout": {
                 "padding": 24

--- a/test/fixtures/controller.line/clip/default-x-min.json
+++ b/test/fixtures/controller.line/clip/default-x-min.json
@@ -16,13 +16,13 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "min": -2,
                     "ticks": {
                         "display": false
                     }
-                }],
-                "yAxes": [{"ticks": {"display": false}}]
+                },
+                "y": {"ticks": {"display": false}}
             },
             "layout": {
                 "padding": 24

--- a/test/fixtures/controller.line/clip/default-x.json
+++ b/test/fixtures/controller.line/clip/default-x.json
@@ -16,14 +16,14 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "min": -2,
                     "max": 3,
                     "ticks": {
                         "display": false
                     }
-                }],
-                "yAxes": [{"ticks": {"display": false}}]
+                },
+                "y": {"ticks": {"display": false}}
             },
             "layout": {
                 "padding": 24

--- a/test/fixtures/controller.line/clip/default-y-max.json
+++ b/test/fixtures/controller.line/clip/default-y-max.json
@@ -16,13 +16,13 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{"ticks": {"display": false}}],
-                "yAxes": [{
+                "x": {"ticks": {"display": false}},
+                "y": {
                     "max": 6,
                     "ticks": {
                         "display": false
                     }
-                }]
+                }
             },
             "layout": {
                 "padding": 24

--- a/test/fixtures/controller.line/clip/default-y-min.json
+++ b/test/fixtures/controller.line/clip/default-y-min.json
@@ -16,13 +16,13 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{"ticks": {"display": false}}],
-                "yAxes": [{
+                "x": {"ticks": {"display": false}},
+                "y": {
                     "min": 2,
                     "ticks": {
                         "display": false
                     }
-                }]
+                }
             },
             "layout": {
                 "padding": 24

--- a/test/fixtures/controller.line/clip/default-y.json
+++ b/test/fixtures/controller.line/clip/default-y.json
@@ -16,14 +16,14 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{"ticks": {"display": false}}],
-                "yAxes": [{
+                "x": {"ticks": {"display": false}},
+                "y": {
                     "min": 2,
                     "max": 6,
                     "ticks": {
                         "display": false
                     }
-                }]
+                }
             },
             "layout": {
                 "padding": 24

--- a/test/fixtures/controller.line/clip/specified.json
+++ b/test/fixtures/controller.line/clip/specified.json
@@ -39,20 +39,20 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "min": -2,
                     "max": 2,
                     "ticks": {
                         "display": false
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "min": -2,
                     "max": 2,
                     "ticks": {
                         "display": false
                     }
-                }]
+                }
             },
             "layout": {
                 "padding": 24

--- a/test/fixtures/controller.line/cubicInterpolationMode/scriptable.js
+++ b/test/fixtures/controller.line/cubicInterpolationMode/scriptable.js
@@ -35,8 +35,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/cubicInterpolationMode/value.js
+++ b/test/fixtures/controller.line/cubicInterpolationMode/value.js
@@ -31,8 +31,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/fill/order-default.js
+++ b/test/fixtures/controller.line/fill/order-default.js
@@ -31,8 +31,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/fill/order.js
+++ b/test/fixtures/controller.line/fill/order.js
@@ -31,8 +31,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/fill/scriptable.js
+++ b/test/fixtures/controller.line/fill/scriptable.js
@@ -33,8 +33,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/fill/value.js
+++ b/test/fixtures/controller.line/fill/value.js
@@ -29,8 +29,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/non-numeric-y.json
+++ b/test/fixtures/controller.line/non-numeric-y.json
@@ -17,11 +17,11 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{
+                "x": {"display": false},
+                "y": {
                     "type": "category",
                     "display": false
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/controller.line/point-style.json
+++ b/test/fixtures/controller.line/point-style.json
@@ -64,12 +64,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{
+                "x": {"display": false},
+                "y": {
                     "display": false,
                     "min": 0,
                     "max": 4
-                }]
+                }
             },
             "elements": {
                 "line": {

--- a/test/fixtures/controller.line/pointBackgroundColor/indexable.js
+++ b/test/fixtures/controller.line/pointBackgroundColor/indexable.js
@@ -42,8 +42,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBackgroundColor/scriptable.js
+++ b/test/fixtures/controller.line/pointBackgroundColor/scriptable.js
@@ -40,13 +40,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBackgroundColor/value.js
+++ b/test/fixtures/controller.line/pointBackgroundColor/value.js
@@ -28,8 +28,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBorderColor/indexable.js
+++ b/test/fixtures/controller.line/pointBorderColor/indexable.js
@@ -42,8 +42,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBorderColor/scriptable.js
+++ b/test/fixtures/controller.line/pointBorderColor/scriptable.js
@@ -40,13 +40,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBorderColor/value.js
+++ b/test/fixtures/controller.line/pointBorderColor/value.js
@@ -28,8 +28,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBorderWidth/indexable.js
+++ b/test/fixtures/controller.line/pointBorderWidth/indexable.js
@@ -34,8 +34,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBorderWidth/scriptable.js
+++ b/test/fixtures/controller.line/pointBorderWidth/scriptable.js
@@ -40,13 +40,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointBorderWidth/value.js
+++ b/test/fixtures/controller.line/pointBorderWidth/value.js
@@ -30,8 +30,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointStyle/indexable.js
+++ b/test/fixtures/controller.line/pointStyle/indexable.js
@@ -46,8 +46,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointStyle/scriptable.js
+++ b/test/fixtures/controller.line/pointStyle/scriptable.js
@@ -44,13 +44,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/pointStyle/value.js
+++ b/test/fixtures/controller.line/pointStyle/value.js
@@ -30,8 +30,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/radius/indexable.js
+++ b/test/fixtures/controller.line/radius/indexable.js
@@ -33,8 +33,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/radius/scriptable.js
+++ b/test/fixtures/controller.line/radius/scriptable.js
@@ -39,13 +39,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/radius/value.js
+++ b/test/fixtures/controller.line/radius/value.js
@@ -29,8 +29,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/rotation/indexable.js
+++ b/test/fixtures/controller.line/rotation/indexable.js
@@ -35,8 +35,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/rotation/scriptable.js
+++ b/test/fixtures/controller.line/rotation/scriptable.js
@@ -41,13 +41,11 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [
-					{
-						display: false,
-						beginAtZero: true
-					}
-				]
+				x: {display: false},
+				y: {
+					display: false,
+					beginAtZero: true
+				}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/rotation/value.js
+++ b/test/fixtures/controller.line/rotation/value.js
@@ -31,8 +31,8 @@ module.exports = {
 				}
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/stacking/order-default.js
+++ b/test/fixtures/controller.line/stacking/order-default.js
@@ -31,8 +31,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{stacked: true, display: false}],
-				yAxes: [{stacked: true, display: false}]
+				x: {stacked: true, display: false},
+				y: {stacked: true, display: false}
 			}
 		}
 	},

--- a/test/fixtures/controller.line/stacking/order-specified.js
+++ b/test/fixtures/controller.line/stacking/order-specified.js
@@ -33,8 +33,8 @@ module.exports = {
 				padding: 32
 			},
 			scales: {
-				xAxes: [{stacked: true, display: false}],
-				yAxes: [{stacked: true, display: false}]
+				x: {stacked: true, display: false},
+				y: {stacked: true, display: false}
 			}
 		}
 	},

--- a/test/fixtures/core.scale/label-offset-vertical-axes.json
+++ b/test/fixtures/core.scale/label-offset-vertical-axes.json
@@ -11,7 +11,7 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "ticks": {
                         "display": false
                     },
@@ -19,8 +19,8 @@
                         "display": false,
                         "drawBorder": false
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "ticks": {
                         "labelOffset": 25
                     },
@@ -28,7 +28,7 @@
                         "display": false,
                         "drawBorder": false
                     }
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/core.scale/tick-drawing.json
+++ b/test/fixtures/core.scale/tick-drawing.json
@@ -9,7 +9,7 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "type": "category",
                     "position": "top",
                     "id": "x-axis-1",
@@ -21,10 +21,10 @@
                         "drawBorder": false,
                         "color": "rgba(0, 0, 0, 1)"
                     }
-                }, {
+                },
+                "x2": {
                     "type": "category",
                     "position": "bottom",
-                    "id": "x-axis-2",
                     "ticks": {
                         "display": false
                     },
@@ -33,36 +33,40 @@
                         "drawBorder": false,
                         "color": "rgba(0, 0, 0, 1)"
                     }
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "position": "left",
                     "id": "y-axis-1",
                     "type": "linear",
+                    "offset": false,
                     "min": -100,
                     "max": 100,
                     "ticks": {
                         "display": false
                     },
                     "gridLines":{
+                        "offsetGridLines": false,
                         "drawOnChartArea": false,
                         "drawBorder": false,
                         "color": "rgba(0, 0, 0, 1)"
                     }
-                }, {
+                },
+                "y2": {
                     "type": "linear",
-                    "id": "y-axis-2",
                     "position": "right",
+                    "offset": false,
                     "min": 0,
                     "max": 50,
                     "ticks": {
                         "display": false
                     },
                     "gridLines":{
+                        "offsetGridLines": false,
                         "drawOnChartArea": false,
                         "drawBorder": false,
                         "color": "rgba(0, 0, 0, 1)"
                     }
-                }]
+                }
             }
         }
     },

--- a/test/fixtures/core.tooltip/opacity.js
+++ b/test/fixtures/core.tooltip/opacity.js
@@ -38,8 +38,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			},
 			elements: {
 				line: {

--- a/test/fixtures/element.line/default.js
+++ b/test/fixtures/element.line/default.js
@@ -12,8 +12,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/skip/all.js
+++ b/test/fixtures/element.line/skip/all.js
@@ -15,8 +15,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/skip/first-span.js
+++ b/test/fixtures/element.line/skip/first-span.js
@@ -16,8 +16,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/skip/first.js
+++ b/test/fixtures/element.line/skip/first.js
@@ -15,8 +15,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/skip/last-span.js
+++ b/test/fixtures/element.line/skip/last-span.js
@@ -16,8 +16,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/skip/last.js
+++ b/test/fixtures/element.line/skip/last.js
@@ -15,8 +15,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/skip/middle-span.js
+++ b/test/fixtures/element.line/skip/middle-span.js
@@ -16,8 +16,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/skip/middle.js
+++ b/test/fixtures/element.line/skip/middle.js
@@ -15,8 +15,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/stepped/after.js
+++ b/test/fixtures/element.line/stepped/after.js
@@ -16,8 +16,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/stepped/before.js
+++ b/test/fixtures/element.line/stepped/before.js
@@ -16,8 +16,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/stepped/default.js
+++ b/test/fixtures/element.line/stepped/default.js
@@ -16,8 +16,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/stepped/middle.js
+++ b/test/fixtures/element.line/stepped/middle.js
@@ -16,8 +16,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/tension/default.js
+++ b/test/fixtures/element.line/tension/default.js
@@ -14,8 +14,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/tension/one.js
+++ b/test/fixtures/element.line/tension/one.js
@@ -15,8 +15,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.line/tension/zero.js
+++ b/test/fixtures/element.line/tension/zero.js
@@ -15,8 +15,8 @@ module.exports = {
 			legend: false,
 			title: false,
 			scales: {
-				xAxes: [{type: 'linear', display: false, min: 0, max: 20}],
-				yAxes: [{display: false, min: -15, max: 15}]
+				x: {type: 'linear', display: false, min: 0, max: 20},
+				y: {display: false, min: -15, max: 15}
 			}
 		}
 	},

--- a/test/fixtures/element.point/point-style-circle.json
+++ b/test/fixtures/element.point/point-style-circle.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-cross-rot.json
+++ b/test/fixtures/element.point/point-style-cross-rot.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-cross.json
+++ b/test/fixtures/element.point/point-style-cross.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-dash.json
+++ b/test/fixtures/element.point/point-style-dash.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-image.js
+++ b/test/fixtures/element.point/point-style-image.js
@@ -44,8 +44,8 @@ module.exports = {
 				padding: 20
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/element.point/point-style-line.json
+++ b/test/fixtures/element.point/point-style-line.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-rect-rot.json
+++ b/test/fixtures/element.point/point-style-rect-rot.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-rect-rounded.json
+++ b/test/fixtures/element.point/point-style-rect-rounded.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-rect.json
+++ b/test/fixtures/element.point/point-style-rect.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-star.json
+++ b/test/fixtures/element.point/point-style-star.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/point-style-triangle.json
+++ b/test/fixtures/element.point/point-style-triangle.json
@@ -53,8 +53,8 @@
                 "padding": 40
             },
             "scales": {
-                "xAxes": [{"display": false}],
-                "yAxes": [{"display": false}]
+                "x": {"display": false},
+                "y": {"display": false}
             }
         }
     },

--- a/test/fixtures/element.point/rotation.js
+++ b/test/fixtures/element.point/rotation.js
@@ -42,8 +42,8 @@ module.exports = {
 				padding: 20
 			},
 			scales: {
-				xAxes: [{display: false}],
-				yAxes: [{display: false}]
+				x: {display: false},
+				y: {display: false}
 			}
 		}
 	},

--- a/test/fixtures/plugin.filler/fill-line-boundary-end-span.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-end-span.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-end.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-end.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-origin-span.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-origin-span.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-origin-spline-span.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-origin-spline-span.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-origin-spline.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-origin-spline.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-origin-stepped-span.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-origin-stepped-span.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-origin-stepped.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-origin-stepped.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-origin.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-origin.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-start-span.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-start-span.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-boundary-start.json
+++ b/test/fixtures/plugin.filler/fill-line-boundary-start.json
@@ -23,12 +23,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-dataset-border.json
+++ b/test/fixtures/plugin.filler/fill-line-dataset-border.json
@@ -31,12 +31,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-dataset-span.json
+++ b/test/fixtures/plugin.filler/fill-line-dataset-span.json
@@ -31,12 +31,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-dataset-spline-span.json
+++ b/test/fixtures/plugin.filler/fill-line-dataset-spline-span.json
@@ -31,12 +31,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-dataset-spline.json
+++ b/test/fixtures/plugin.filler/fill-line-dataset-spline.json
@@ -31,12 +31,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/plugin.filler/fill-line-dataset.json
+++ b/test/fixtures/plugin.filler/fill-line-dataset.json
@@ -31,12 +31,12 @@
             "legend": false,
             "title": false,
             "scales": {
-                "xAxes": [{
+                "x": {
                     "display": false
-                }],
-                "yAxes": [{
+                },
+                "y": {
                     "display": false
-                }]
+                }
             },
             "elements": {
                 "point": {

--- a/test/fixtures/scale.radialLinear/indexable-gridlines.json
+++ b/test/fixtures/scale.radialLinear/indexable-gridlines.json
@@ -10,6 +10,7 @@
             "title": false,
             "scale": {
                 "gridLines": {
+                    "display": true,
                     "color": [
                         "rgba(0, 0, 0, 0.5)",
                         "rgba(255, 255, 255, 0.5)",

--- a/test/specs/controller.bar.tests.js
+++ b/test/specs/controller.bar.tests.js
@@ -41,21 +41,11 @@ describe('Chart.controllers.bar', function() {
 				],
 				labels: []
 			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}]
-				}
-			}
 		});
 
 		var meta = chart.getDatasetMeta(1);
-		expect(meta.xAxisID).toBe('firstXScaleID');
-		expect(meta.yAxisID).toBe('firstYScaleID');
+		expect(meta.xAxisID).toBe('x');
+		expect(meta.yAxisID).toBe('y');
 	});
 
 	it('should correctly count the number of stacks ignoring datasets of other types and hidden datasets', function() {
@@ -122,12 +112,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -155,12 +145,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -211,12 +201,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -244,12 +234,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -300,12 +290,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -333,12 +323,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -416,12 +406,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -452,12 +442,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -514,12 +504,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -550,12 +540,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -612,12 +602,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			});
@@ -648,12 +638,12 @@ describe('Chart.controllers.bar', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: false
-						}]
+						}
 					}
 				}
 			});
@@ -712,16 +702,14 @@ describe('Chart.controllers.bar', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
-						id: 'firstXScaleID',
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
-						id: 'firstYScaleID',
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -778,14 +766,14 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -819,15 +807,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -878,17 +866,17 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true,
 						min: 50,
 						max: 100
-					}]
+					}
 				}
 			}
 		});
@@ -939,15 +927,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false,
 						stacked: true
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -998,15 +986,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1059,15 +1047,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1118,15 +1106,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true,
-					}]
+					}
 				}
 			}
 		});
@@ -1164,15 +1152,15 @@ describe('Chart.controllers.bar', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1212,16 +1200,16 @@ describe('Chart.controllers.bar', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false,
 						stacked: true,
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'logarithmic',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1277,16 +1265,16 @@ describe('Chart.controllers.bar', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false,
 						stacked: true,
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'logarithmic',
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1511,10 +1499,10 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							min: 'March',
 							max: 'May',
-						}]
+						}
 					}
 				}
 			};
@@ -1526,13 +1514,13 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							min: 'March',
 							max: 'May',
-						}],
-						yAxes: [{
+						},
+						y: {
 							stacked: true
-						}]
+						}
 					}
 				}
 			};
@@ -1585,10 +1573,10 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						yAxes: [{
+						y: {
 							min: 'March',
 							max: 'May',
-						}]
+						}
 					}
 				}
 			};
@@ -1600,13 +1588,13 @@ describe('Chart.controllers.bar', function() {
 				data: this.data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							stacked: true
-						}],
-						yAxes: [{
+						},
+						y: {
 							min: 'March',
 							max: 'May',
-						}]
+						}
 					}
 				}
 			};
@@ -1636,13 +1624,13 @@ describe('Chart.controllers.bar', function() {
 								}
 							},
 							scales: {
-								xAxes: [{
+								x: {
 									id: 'x',
 									type: 'category',
-								}],
-								yAxes: [{
+								},
+								y: {
 									type: 'linear',
-								}]
+								}
 							}
 						}
 					});
@@ -1724,5 +1712,4 @@ describe('Chart.controllers.bar', function() {
 		expect(data[0]._model.base + minBarLength).toEqual(data[0]._model.x);
 		expect(data[1]._model.base - minBarLength).toEqual(data[1]._model.x);
 	});
-
 });

--- a/test/specs/controller.bubble.tests.js
+++ b/test/specs/controller.bubble.tests.js
@@ -33,22 +33,12 @@ describe('Chart.controllers.bubble', function() {
 					data: []
 				}]
 			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}]
-				}
-			}
 		});
 
 		var meta = chart.getDatasetMeta(0);
 
-		expect(meta.xAxisID).toBe('firstXScaleID');
-		expect(meta.yAxisID).toBe('firstYScaleID');
+		expect(meta.xAxisID).toBe('x');
+		expect(meta.yAxisID).toBe('y');
 	});
 
 	it('should create point elements for each data item during initialization', function() {
@@ -128,14 +118,14 @@ describe('Chart.controllers.bubble', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'category',
 						display: false
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						display: false
-					}]
+					}
 				}
 			}
 		});

--- a/test/specs/controller.line.tests.js
+++ b/test/specs/controller.line.tests.js
@@ -35,21 +35,11 @@ describe('Chart.controllers.line', function() {
 				}],
 				labels: []
 			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}]
-				}
-			}
 		});
 
 		var meta = chart.getDatasetMeta(0);
-		expect(meta.xAxisID).toBe('firstXScaleID');
-		expect(meta.yAxisID).toBe('firstYScaleID');
+		expect(meta.xAxisID).toBe('x');
+		expect(meta.yAxisID).toBe('y');
 	});
 
 	it('Should create line elements and point elements for each data item during initialization', function() {
@@ -173,8 +163,8 @@ describe('Chart.controllers.line', function() {
 				datasets: [{
 					data: [10, 15, 0, -4],
 					label: 'dataset',
-					xAxisID: 'firstXScaleID',
-					yAxisID: 'firstYScaleID'
+					xAxisID: 'x',
+					yAxisID: 'y'
 				}],
 				labels: ['label1', 'label2', 'label3', 'label4']
 			},
@@ -189,14 +179,12 @@ describe('Chart.controllers.line', function() {
 					}
 				},
 				scales: {
-					xAxes: [{
-						id: 'firstXScaleID',
+					x: {
 						display: false
-					}],
-					yAxes: [{
-						id: 'firstYScaleID',
+					},
+					y: {
 						display: false
-					}]
+					}
 				}
 			},
 		});
@@ -246,13 +234,13 @@ describe('Chart.controllers.line', function() {
 					intersect: true
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						beginAtZero: true
-					}]
+					}
 				}
 			}
 		});
@@ -313,13 +301,13 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -363,7 +351,7 @@ describe('Chart.controllers.line', function() {
 				}, {
 					data: [10, 10, -10, -10],
 					label: 'dataset3',
-					yAxisID: 'secondAxis'
+					yAxisID: 'y2'
 				}],
 				labels: ['label1', 'label2', 'label3', 'label4']
 			},
@@ -371,17 +359,18 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}, {
-						id: 'secondAxis',
+					},
+					y2: {
 						type: 'linear',
+						position: 'right',
 						display: false
-					}]
+					}
 				}
 			}
 		});
@@ -453,13 +442,13 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -507,13 +496,13 @@ describe('Chart.controllers.line', function() {
 				legend: false,
 				title: false,
 				scales: {
-					xAxes: [{
+					x: {
 						display: false,
-					}],
-					yAxes: [{
+					},
+					y: {
 						display: false,
 						stacked: true
-					}]
+					}
 				}
 			}
 		});

--- a/test/specs/core.controller.tests.js
+++ b/test/specs/core.controller.tests.js
@@ -130,19 +130,19 @@ describe('Chart', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							position: 'left',
-						}],
-						yAxes: [{
+						},
+						y: {
 							position: 'bottom'
-						}]
+						}
 					}
 				}
 			});
 
 			var scaleOptions = chart.options.scales;
-			expect(scaleOptions.xAxes[0].position).toBe('bottom');
-			expect(scaleOptions.yAxes[0].position).toBe('left');
+			expect(scaleOptions.x.position).toBe('bottom');
+			expect(scaleOptions.y.position).toBe('left');
 		});
 
 		it('should throw an error if the chart type is incorrect', function() {
@@ -158,12 +158,14 @@ describe('Chart', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
+							x: {
+								type: 'linear',
 								position: 'left',
-							}],
-							yAxes: [{
+							},
+							y: {
+								type: 'category',
 								position: 'bottom'
-							}]
+							}
 						}
 					}
 				});
@@ -199,22 +201,18 @@ describe('Chart', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [
-							{id: 'foo0'},
-							{id: 'foo1'}
-						],
-						yAxes: [
-							{id: 'bar0'},
-							{id: 'bar1'}
-						]
+						xFoo0: {},
+						xFoo1: {},
+						yBar0: {},
+						yBar1: {},
 					}
 				}
 			});
 
-			expect(chart.scales.foo0.type).toBe('category');
-			expect(chart.scales.foo1.type).toBe('category');
-			expect(chart.scales.bar0.type).toBe('linear');
-			expect(chart.scales.bar1.type).toBe('linear');
+			expect(chart.scales.xFoo0.type).toBe('category');
+			expect(chart.scales.xFoo1.type).toBe('category');
+			expect(chart.scales.yBar0.type).toBe('linear');
+			expect(chart.scales.yBar1.type).toBe('linear');
 		});
 
 		it('should correctly apply defaults on central scale', function() {
@@ -233,7 +231,7 @@ describe('Chart', function() {
 			// let's check a few values from the user options and defaults
 
 			expect(chart.scales.foo.type).toBe('logarithmic');
-			expect(chart.scales.foo.options).toBe(chart.options.scale);
+			expect(chart.scales.foo.options).toEqual(chart.options.scales.foo);
 			expect(chart.scales.foo.options).toEqual(
 				jasmine.objectContaining({
 					_jasmineCheckA: 'a0',
@@ -248,25 +246,23 @@ describe('Chart', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'foo',
+						x: {
 							type: 'logarithmic',
 							_jasmineCheckC: 'c2',
 							_jasmineCheckD: 'd2'
-						}],
-						yAxes: [{
-							id: 'bar',
+						},
+						y: {
 							type: 'time',
 							_jasmineCheckC: 'c2',
 							_jasmineCheckE: 'e2'
-						}]
+						}
 					}
 				}
 			});
 
-			expect(chart.scales.foo.type).toBe('logarithmic');
-			expect(chart.scales.foo.options).toBe(chart.options.scales.xAxes[0]);
-			expect(chart.scales.foo.options).toEqual(
+			expect(chart.scales.x.type).toBe('logarithmic');
+			expect(chart.scales.x.options).toBe(chart.options.scales.x);
+			expect(chart.scales.x.options).toEqual(
 				jasmine.objectContaining({
 					_jasmineCheckA: 'a0',
 					_jasmineCheckB: 'b1',
@@ -274,9 +270,9 @@ describe('Chart', function() {
 					_jasmineCheckD: 'd2'
 				}));
 
-			expect(chart.scales.bar.type).toBe('time');
-			expect(chart.scales.bar.options).toBe(chart.options.scales.yAxes[0]);
-			expect(chart.scales.bar.options).toEqual(
+			expect(chart.scales.y.type).toBe('time');
+			expect(chart.scales.y.options).toBe(chart.options.scales.y);
+			expect(chart.scales.y.options).toEqual(
 				jasmine.objectContaining({
 					_jasmineCheckA: 'a0',
 					_jasmineCheckB: 'b0',
@@ -291,23 +287,21 @@ describe('Chart', function() {
 				options: {
 					_jasmineCheck: 42,
 					scales: {
-						xAxes: [{
-							id: 'foo',
+						x: {
 							type: 'linear',
 							_jasmineCheck: 42,
-						}],
-						yAxes: [{
-							id: 'bar',
+						},
+						y: {
 							type: 'category',
 							_jasmineCheck: 42,
-						}]
+						}
 					}
 				}
 			});
 
 			expect(chart.options._jasmineCheck).toBeDefined();
-			expect(chart.scales.foo.options._jasmineCheck).toBeDefined();
-			expect(chart.scales.bar.options._jasmineCheck).toBeDefined();
+			expect(chart.scales.x.options._jasmineCheck).toBeDefined();
+			expect(chart.scales.y.options._jasmineCheck).toBeDefined();
 
 			expect(Chart.defaults.line._jasmineCheck).not.toBeDefined();
 			expect(Chart.defaults.global._jasmineCheck).not.toBeDefined();
@@ -989,15 +983,15 @@ describe('Chart', function() {
 			chart.options = {
 				responsive: false,
 				scales: {
-					yAxes: [{
+					y: {
 						min: 0,
 						max: 10
-					}]
+					}
 				}
 			};
 			chart.update();
 
-			var yScale = chart.scales['y-axis-0'];
+			var yScale = chart.scales.y;
 			expect(yScale.options.min).toBe(0);
 			expect(yScale.options.max).toBe(10);
 		});
@@ -1016,11 +1010,11 @@ describe('Chart', function() {
 				}
 			});
 
-			chart.options.scales.yAxes[0].min = 0;
-			chart.options.scales.yAxes[0].max = 10;
+			chart.options.scales.y.min = 0;
+			chart.options.scales.y.max = 10;
 			chart.update();
 
-			var yScale = chart.scales['y-axis-0'];
+			var yScale = chart.scales.y;
 			expect(yScale.options.min).toBe(0);
 			expect(yScale.options.max).toBe(10);
 		});
@@ -1040,35 +1034,18 @@ describe('Chart', function() {
 			});
 
 			var newScalesConfig = {
-				yAxes: [{
+				y: {
 					min: 0,
 					max: 10
-				}]
+				}
 			};
 			chart.options.scales = newScalesConfig;
 
 			chart.update();
 
-			var yScale = chart.scales['y-axis-0'];
+			var yScale = chart.scales.y;
 			expect(yScale.options.min).toBe(0);
 			expect(yScale.options.max).toBe(10);
-		});
-
-		it ('should assign unique scale IDs', function() {
-			var chart = acquireChart({
-				type: 'line',
-				options: {
-					scales: {
-						xAxes: [{id: 'x-axis-0'}, {}, {}],
-						yAxes: [{id: 'y-axis-1'}, {}, {}]
-					}
-				}
-			});
-
-			expect(Object.keys(chart.scales).sort()).toEqual([
-				'x-axis-0', 'x-axis-1', 'x-axis-2',
-				'y-axis-1', 'y-axis-2', 'y-axis-3'
-			]);
 		});
 
 		it ('should remove discarded scale', function() {
@@ -1083,20 +1060,19 @@ describe('Chart', function() {
 				options: {
 					responsive: true,
 					scales: {
-						yAxes: [{
-							id: 'yAxis0',
+						y: {
 							min: 0,
 							max: 10
-						}]
+						}
 					}
 				}
 			});
 
 			var newScalesConfig = {
-				yAxes: [{
+				y: {
 					min: 0,
 					max: 10
-				}]
+				}
 			};
 			chart.options.scales = newScalesConfig;
 
@@ -1104,7 +1080,7 @@ describe('Chart', function() {
 
 			var yScale = chart.scales.yAxis0;
 			expect(yScale).toBeUndefined();
-			var newyScale = chart.scales['y-axis-0'];
+			var newyScale = chart.scales.y;
 			expect(newyScale.options.min).toBe(0);
 			expect(newyScale.options.max).toBe(10);
 		});
@@ -1181,15 +1157,16 @@ describe('Chart', function() {
 				options: {
 					responsive: true,
 					scales: {
-						xAxes: [{
+						x: {
 							type: 'category'
-						}],
-						yAxes: [{
+						},
+						y: {
+							type: 'linear',
 							scaleLabel: {
 								display: true,
 								labelString: 'Value'
 							}
-						}]
+						}
 					}
 				}
 			};

--- a/test/specs/core.datasetController.tests.js
+++ b/test/specs/core.datasetController.tests.js
@@ -233,16 +233,22 @@ describe('Chart.DatasetController', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'firstXScaleID'
-					}, {
-						id: 'secondXScaleID'
-					}],
-					yAxes: [{
-						id: 'firstYScaleID'
-					}, {
-						id: 'secondYScaleID'
-					}]
+					firstXScaleID: {
+						type: 'category',
+						position: 'bottom'
+					},
+					secondXScaleID: {
+						type: 'category',
+						position: 'bottom'
+					},
+					firstYScaleID: {
+						type: 'linear',
+						position: 'left'
+					},
+					secondYScaleID: {
+						type: 'linear',
+						position: 'left'
+					},
 				}
 			}
 		});

--- a/test/specs/core.layouts.tests.js
+++ b/test/specs/core.layouts.tests.js
@@ -21,18 +21,6 @@ describe('Chart.layouts', function() {
 					{data: [10, 5, 0, 25, 78, -10]}
 				],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5', 'tick6']
-			},
-			options: {
-				scales: {
-					xAxes: [{
-						id: 'xScale',
-						type: 'category'
-					}],
-					yAxes: [{
-						id: 'yScale',
-						type: 'linear'
-					}]
-				}
 			}
 		}, {
 			canvas: {
@@ -47,18 +35,18 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(32);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(150);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(34);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(247);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(120);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(150);
+		expect(chart.scales.x.left).toBeCloseToPixel(34);
+		expect(chart.scales.x.right).toBeCloseToPixel(247);
+		expect(chart.scales.x.top).toBeCloseToPixel(120);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(0);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(120);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(34);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(32);
-		expect(chart.scales.yScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(120);
+		expect(chart.scales.y.left).toBeCloseToPixel(0);
+		expect(chart.scales.y.right).toBeCloseToPixel(34);
+		expect(chart.scales.y.top).toBeCloseToPixel(32);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 	});
 
 	it('should fit scales that are in the top and right positions', function() {
@@ -72,16 +60,14 @@ describe('Chart.layouts', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'category',
 						position: 'top'
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'linear',
 						position: 'right'
-					}]
+					}
 				}
 			}
 		}, {
@@ -97,18 +83,18 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(62);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(62);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(3);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(216);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(32);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(62);
+		expect(chart.scales.x.left).toBeCloseToPixel(3);
+		expect(chart.scales.x.right).toBeCloseToPixel(216);
+		expect(chart.scales.x.top).toBeCloseToPixel(32);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(0);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(142);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(216);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(250);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(62);
-		expect(chart.scales.yScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(142);
+		expect(chart.scales.y.left).toBeCloseToPixel(216);
+		expect(chart.scales.y.right).toBeCloseToPixel(250);
+		expect(chart.scales.y.top).toBeCloseToPixel(62);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 	});
 
 	it('should fit scales with long labels correctly', function() {
@@ -125,19 +111,17 @@ describe('Chart.layouts', function() {
 					display: false
 				},
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'category',
 						ticks: {
 							maxRotation: 0,
 							autoSkip: false
 						}
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'linear',
 						position: 'right'
-					}]
+					}
 				}
 			}
 		}, {
@@ -153,30 +137,30 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(7);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(150);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(60);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(452);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(120);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(150);
+		expect(chart.scales.x.left).toBeCloseToPixel(60);
+		expect(chart.scales.x.right).toBeCloseToPixel(452);
+		expect(chart.scales.x.top).toBeCloseToPixel(120);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(0);
 
-		expect(chart.scales.xScale.height).toBeCloseToPixel(30);
-		expect(chart.scales.xScale.paddingLeft).toBeCloseToPixel(60);
-		expect(chart.scales.xScale.paddingTop).toBeCloseToPixel(0);
-		expect(chart.scales.xScale.paddingRight).toBeCloseToPixel(60);
-		expect(chart.scales.xScale.paddingBottom).toBeCloseToPixel(0);
+		expect(chart.scales.x.height).toBeCloseToPixel(30);
+		expect(chart.scales.x.paddingLeft).toBeCloseToPixel(60);
+		expect(chart.scales.x.paddingTop).toBeCloseToPixel(0);
+		expect(chart.scales.x.paddingRight).toBeCloseToPixel(60);
+		expect(chart.scales.x.paddingBottom).toBeCloseToPixel(0);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(120);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(452);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(486);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(7);
-		expect(chart.scales.yScale.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(120);
+		expect(chart.scales.y.left).toBeCloseToPixel(452);
+		expect(chart.scales.y.right).toBeCloseToPixel(486);
+		expect(chart.scales.y.top).toBeCloseToPixel(7);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 
-		expect(chart.scales.yScale.width).toBeCloseToPixel(34);
-		expect(chart.scales.yScale.paddingLeft).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.paddingTop).toBeCloseToPixel(7);
-		expect(chart.scales.yScale.paddingRight).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.paddingBottom).toBeCloseToPixel(7);
+		expect(chart.scales.y.width).toBeCloseToPixel(34);
+		expect(chart.scales.y.paddingLeft).toBeCloseToPixel(0);
+		expect(chart.scales.y.paddingTop).toBeCloseToPixel(7);
+		expect(chart.scales.y.paddingRight).toBeCloseToPixel(0);
+		expect(chart.scales.y.paddingBottom).toBeCloseToPixel(7);
 	});
 
 	it('should fit scales that overlap the chart area', function() {
@@ -197,12 +181,13 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.right).toBeCloseToPixel(512);
 		expect(chart.chartArea.top).toBeCloseToPixel(32);
 
-		expect(chart.scale.bottom).toBeCloseToPixel(512);
-		expect(chart.scale.left).toBeCloseToPixel(0);
-		expect(chart.scale.right).toBeCloseToPixel(512);
-		expect(chart.scale.top).toBeCloseToPixel(32);
-		expect(chart.scale.width).toBeCloseToPixel(512);
-		expect(chart.scale.height).toBeCloseToPixel(480);
+		var scale = chart.scales.r;
+		expect(scale.bottom).toBeCloseToPixel(512);
+		expect(scale.left).toBeCloseToPixel(0);
+		expect(scale.right).toBeCloseToPixel(512);
+		expect(scale.top).toBeCloseToPixel(32);
+		expect(scale.width).toBeCloseToPixel(512);
+		expect(scale.height).toBeCloseToPixel(480);
 	});
 
 	it('should fit multiple axes in the same position', function() {
@@ -210,27 +195,25 @@ describe('Chart.layouts', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale1',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78, -10]
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [-19, -20, 0, -99, -50, 0]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5', 'tick6']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'category'
-					}],
-					yAxes: [{
-						id: 'yScale1',
+					},
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale2',
+					},
+					y2: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		}, {
@@ -246,24 +229,24 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(32);
 
 		// Is xScale at the right spot
-		expect(chart.scales.xScale.bottom).toBeCloseToPixel(150);
-		expect(chart.scales.xScale.left).toBeCloseToPixel(73);
-		expect(chart.scales.xScale.right).toBeCloseToPixel(247);
-		expect(chart.scales.xScale.top).toBeCloseToPixel(118);
-		expect(chart.scales.xScale.labelRotation).toBeCloseTo(40, -1);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(150);
+		expect(chart.scales.x.left).toBeCloseToPixel(73);
+		expect(chart.scales.x.right).toBeCloseToPixel(247);
+		expect(chart.scales.x.top).toBeCloseToPixel(118);
+		expect(chart.scales.x.labelRotation).toBeCloseTo(40, -1);
 
 		// Are yScales at the right spot
-		expect(chart.scales.yScale1.bottom).toBeCloseToPixel(118);
-		expect(chart.scales.yScale1.left).toBeCloseToPixel(41);
-		expect(chart.scales.yScale1.right).toBeCloseToPixel(73);
-		expect(chart.scales.yScale1.top).toBeCloseToPixel(32);
-		expect(chart.scales.yScale1.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(118);
+		expect(chart.scales.y.left).toBeCloseToPixel(41);
+		expect(chart.scales.y.right).toBeCloseToPixel(73);
+		expect(chart.scales.y.top).toBeCloseToPixel(32);
+		expect(chart.scales.y.labelRotation).toBeCloseTo(0);
 
-		expect(chart.scales.yScale2.bottom).toBeCloseToPixel(118);
-		expect(chart.scales.yScale2.left).toBeCloseToPixel(0);
-		expect(chart.scales.yScale2.right).toBeCloseToPixel(41);
-		expect(chart.scales.yScale2.top).toBeCloseToPixel(32);
-		expect(chart.scales.yScale2.labelRotation).toBeCloseTo(0);
+		expect(chart.scales.y2.bottom).toBeCloseToPixel(118);
+		expect(chart.scales.y2.left).toBeCloseToPixel(0);
+		expect(chart.scales.y2.right).toBeCloseToPixel(41);
+		expect(chart.scales.y2.top).toBeCloseToPixel(32);
+		expect(chart.scales.y2.labelRotation).toBeCloseTo(0);
 	});
 
 	it ('should fit a full width box correctly', function() {
@@ -271,29 +254,29 @@ describe('Chart.layouts', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale1',
+					xAxisID: 'x',
 					data: [10, 5, 0, 25, 78, -10]
 				}, {
-					xAxisID: 'xScale2',
+					xAxisID: 'x2',
 					data: [-19, -20, 0, -99, -50, 0]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5', 'tick6']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale1',
-						type: 'category'
-					}, {
-						id: 'xScale2',
+					x: {
+						type: 'category',
+						offset: false
+					},
+					x2: {
 						type: 'category',
 						position: 'top',
-						fullWidth: true
-					}],
-					yAxes: [{
-						id: 'yScale',
+						fullWidth: true,
+						offset: false
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
@@ -304,21 +287,21 @@ describe('Chart.layouts', function() {
 		expect(chart.chartArea.top).toBeCloseToPixel(62);
 
 		// Are xScales at the right spot
-		expect(chart.scales.xScale1.bottom).toBeCloseToPixel(512);
-		expect(chart.scales.xScale1.left).toBeCloseToPixel(40);
-		expect(chart.scales.xScale1.right).toBeCloseToPixel(496);
-		expect(chart.scales.xScale1.top).toBeCloseToPixel(484);
+		expect(chart.scales.x.bottom).toBeCloseToPixel(512);
+		expect(chart.scales.x.left).toBeCloseToPixel(40);
+		expect(chart.scales.x.right).toBeCloseToPixel(496);
+		expect(chart.scales.x.top).toBeCloseToPixel(484);
 
-		expect(chart.scales.xScale2.bottom).toBeCloseToPixel(62);
-		expect(chart.scales.xScale2.left).toBeCloseToPixel(0);
-		expect(chart.scales.xScale2.right).toBeCloseToPixel(512);
-		expect(chart.scales.xScale2.top).toBeCloseToPixel(32);
+		expect(chart.scales.x2.bottom).toBeCloseToPixel(62);
+		expect(chart.scales.x2.left).toBeCloseToPixel(0);
+		expect(chart.scales.x2.right).toBeCloseToPixel(512);
+		expect(chart.scales.x2.top).toBeCloseToPixel(32);
 
 		// Is yScale at the right spot
-		expect(chart.scales.yScale.bottom).toBeCloseToPixel(484);
-		expect(chart.scales.yScale.left).toBeCloseToPixel(0);
-		expect(chart.scales.yScale.right).toBeCloseToPixel(40);
-		expect(chart.scales.yScale.top).toBeCloseToPixel(62);
+		expect(chart.scales.y.bottom).toBeCloseToPixel(484);
+		expect(chart.scales.y.left).toBeCloseToPixel(0);
+		expect(chart.scales.y.right).toBeCloseToPixel(40);
+		expect(chart.scales.y.top).toBeCloseToPixel(62);
 	});
 
 	describe('padding settings', function() {
@@ -335,16 +318,14 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale',
+						x: {
 							type: 'category',
 							display: false
-						}],
-						yAxes: [{
-							id: 'yScale',
+						},
+						y: {
 							type: 'linear',
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -382,16 +363,14 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale',
+						x: {
 							type: 'category',
 							display: false
-						}],
-						yAxes: [{
-							id: 'yScale',
+						},
+						y: {
 							type: 'linear',
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -434,16 +413,14 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale',
+						x: {
 							type: 'category',
 							display: false
-						}],
-						yAxes: [{
-							id: 'yScale',
+						},
+						y: {
 							type: 'linear',
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -498,8 +475,8 @@ describe('Chart.layouts', function() {
 				}
 			});
 
-			var xAxis = chart.scales['x-axis-0'];
-			var yAxis = chart.scales['y-axis-0'];
+			var xAxis = chart.scales.x;
+			var yAxis = chart.scales.y;
 			var legend = chart.legend;
 			var title = chart.titleBlock;
 
@@ -520,60 +497,63 @@ describe('Chart.layouts', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'category',
+							position: 'bottom',
 							display: true,
 							weight: 1
-						}, {
-							id: 'xScale1',
+						},
+						x1: {
 							type: 'category',
+							position: 'bottom',
 							display: true,
 							weight: 2
-						}, {
-							id: 'xScale2',
+						},
+						x2: {
 							type: 'category',
+							position: 'bottom',
 							display: true
-						}, {
-							id: 'xScale3',
+						},
+						x3: {
 							type: 'category',
 							display: true,
 							position: 'top',
 							weight: 1
-						}, {
-							id: 'xScale4',
+						},
+						x4: {
 							type: 'category',
 							display: true,
 							position: 'top',
 							weight: 2
-						}],
-						yAxes: [{
-							id: 'yScale0',
+						},
+						y: {
 							type: 'linear',
 							display: true,
 							weight: 1
-						}, {
-							id: 'yScale1',
+						},
+						y1: {
 							type: 'linear',
+							position: 'left',
 							display: true,
 							weight: 2
-						}, {
-							id: 'yScale2',
+						},
+						y2: {
 							type: 'linear',
+							position: 'left',
 							display: true
-						}, {
-							id: 'yScale3',
+						},
+						y3: {
 							type: 'linear',
 							display: true,
 							position: 'right',
 							weight: 1
-						}, {
-							id: 'yScale4',
+						},
+						y4: {
 							type: 'linear',
 							display: true,
 							position: 'right',
 							weight: 2
-						}]
+						}
 					}
 				}
 			}, {
@@ -583,17 +563,17 @@ describe('Chart.layouts', function() {
 				}
 			});
 
-			var xScale0 = chart.scales.xScale0;
-			var xScale1 = chart.scales.xScale1;
-			var xScale2 = chart.scales.xScale2;
-			var xScale3 = chart.scales.xScale3;
-			var xScale4 = chart.scales.xScale4;
+			var xScale0 = chart.scales.x;
+			var xScale1 = chart.scales.x1;
+			var xScale2 = chart.scales.x2;
+			var xScale3 = chart.scales.x3;
+			var xScale4 = chart.scales.x4;
 
-			var yScale0 = chart.scales.yScale0;
-			var yScale1 = chart.scales.yScale1;
-			var yScale2 = chart.scales.yScale2;
-			var yScale3 = chart.scales.yScale3;
-			var yScale4 = chart.scales.yScale4;
+			var yScale0 = chart.scales.y;
+			var yScale1 = chart.scales.y1;
+			var yScale2 = chart.scales.y2;
+			var yScale3 = chart.scales.y3;
+			var yScale4 = chart.scales.y4;
 
 			expect(xScale0.weight).toBe(1);
 			expect(xScale1.weight).toBe(2);
@@ -650,7 +630,7 @@ describe('Chart.layouts', function() {
 					width: 256
 				}
 			});
-			var yAxis = chart.scales['y-axis-0'];
+			var yAxis = chart.scales.y;
 
 			// issue #4441: y-axis labels partially hidden.
 			// minimum horizontal space required to fit labels

--- a/test/specs/core.scale.tests.js
+++ b/test/specs/core.scale.tests.js
@@ -28,18 +28,18 @@ describe('Core.scale', function() {
 				data: data,
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							ticks: {
 								autoSkip: true
 							}
-						}]
+						}
 					}
 				}
 			});
 		}
 
 		function lastTick(chart) {
-			var xAxis = chart.scales['x-axis-0'];
+			var xAxis = chart.scales.x;
 			var ticks = xAxis.getTicks();
 			return ticks[ticks.length - 1];
 		}
@@ -133,8 +133,7 @@ describe('Core.scale', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							gridLines: {
 								offsetGridLines: test.offsetGridLines,
 								drawTicks: false
@@ -143,10 +142,10 @@ describe('Core.scale', function() {
 								display: false
 							},
 							offset: test.offset
-						}],
-						yAxes: [{
+						},
+						y: {
 							display: false
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -154,7 +153,7 @@ describe('Core.scale', function() {
 				}
 			});
 
-			var xScale = chart.scales.xScale0;
+			var xScale = chart.scales.x;
 			xScale.ctx = window.createMockContext();
 			chart.draw();
 
@@ -178,12 +177,11 @@ describe('Core.scale', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							display: false
-						}],
-						yAxes: [{
+						},
+						y: {
 							type: 'category',
-							id: 'yScale0',
 							gridLines: {
 								offsetGridLines: test.offsetGridLines,
 								drawTicks: false
@@ -192,7 +190,7 @@ describe('Core.scale', function() {
 								display: false
 							},
 							offset: test.offset
-						}]
+						}
 					},
 					legend: {
 						display: false
@@ -200,7 +198,7 @@ describe('Core.scale', function() {
 				}
 			});
 
-			var yScale = chart.scales.yScale0;
+			var yScale = chart.scales.y;
 			yScale.ctx = window.createMockContext();
 			chart.draw();
 
@@ -226,12 +224,9 @@ describe('Core.scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'foo'
-					}],
-					yAxes: [{
+					y: {
 						display: false
-					}]
+					}
 				},
 				legend: {
 					display: false
@@ -244,7 +239,7 @@ describe('Core.scale', function() {
 			}
 		});
 
-		var scale = chart.scales.foo;
+		var scale = chart.scales.x;
 		expect(scale.left).toBeGreaterThan(100);
 		expect(scale.right).toBeGreaterThan(190);
 	});
@@ -268,19 +263,17 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'foo',
+							x: {
 								display: 'auto'
-							}],
-							yAxes: [{
+							},
+							y: {
 								type: 'category',
-								id: 'yScale0'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.x;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -301,15 +294,14 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'foo',
+							x: {
 								display: 'auto'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.x;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -336,15 +328,14 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							yAxes: [{
-								id: 'foo',
+							y: {
 								display: 'auto'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.y;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -365,15 +356,14 @@ describe('Core.scale', function() {
 					},
 					options: {
 						scales: {
-							yAxes: [{
-								id: 'foo',
+							y: {
 								display: 'auto'
-							}]
+							}
 						}
 					}
 				});
 
-				var scale = chart.scales.foo;
+				var scale = chart.scales.y;
 				scale.ctx = window.createMockContext();
 				chart.draw();
 
@@ -390,14 +380,13 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'category',
 							labels: labels,
 							afterBuildTicks: function(scale) {
 								scale.ticks = scale.ticks.slice(1);
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -412,12 +401,11 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'category',
 							labels: labels,
 							afterBuildTicks: function() { }
-						}]
+						}
 					}
 				}
 			});
@@ -432,14 +420,13 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'category',
 							labels: labels,
 							afterBuildTicks: function(scale) {
 								scale.ticks = [];
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -455,10 +442,9 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
-						}]
+						}
 					}
 				}
 			});
@@ -480,8 +466,7 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'customScale',
 							gridLines: {
 								z: 10
@@ -489,7 +474,7 @@ describe('Core.scale', function() {
 							ticks: {
 								z: 20
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -504,8 +489,7 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							ticks: {
 								z: 10
@@ -513,7 +497,7 @@ describe('Core.scale', function() {
 							gridLines: {
 								z: 10
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -528,13 +512,12 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							ticks: {
 								z: 10
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -545,13 +528,12 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							gridLines: {
 								z: 11
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -562,8 +544,7 @@ describe('Core.scale', function() {
 				type: 'line',
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'linear',
 							ticks: {
 								z: 10
@@ -571,7 +552,7 @@ describe('Core.scale', function() {
 							gridLines: {
 								z: 11
 							}
-						}]
+						}
 					}
 				}
 			});
@@ -595,16 +576,16 @@ describe('Core.scale', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
+						x: {
 							id: 'x',
 							type: 'linear',
 							min: -20,
 							max: 20
-						}],
-						yAxes: [{
+						},
+						y: {
 							id: 'y',
 							type: 'linear'
-						}]
+						}
 					}
 				}
 			});

--- a/test/specs/core.ticks.tests.js
+++ b/test/specs/core.ticks.tests.js
@@ -25,7 +25,7 @@ describe('Test tick generators', function() {
 					display: false,
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'linear',
 						position: 'bottom',
 						ticks: {
@@ -33,21 +33,21 @@ describe('Test tick generators', function() {
 								return value.toString();
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'linear',
 						ticks: {
 							callback: function(value) {
 								return value.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var xLabels = getLabels(chart.scales['x-axis-0']);
-		var yLabels = getLabels(chart.scales['y-axis-0']);
+		var xLabels = getLabels(chart.scales.x);
+		var yLabels = getLabels(chart.scales.y);
 
 		expect(xLabels).toEqual(['0', '0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1']);
 		expect(yLabels).toEqual(['1', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1', '0']);
@@ -66,7 +66,7 @@ describe('Test tick generators', function() {
 					display: false,
 				},
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'logarithmic',
 						position: 'bottom',
 						min: 0.1,
@@ -76,8 +76,8 @@ describe('Test tick generators', function() {
 								return value.toString();
 							}
 						}
-					}],
-					yAxes: [{
+					},
+					y: {
 						type: 'logarithmic',
 						min: 0.1,
 						max: 1,
@@ -86,13 +86,13 @@ describe('Test tick generators', function() {
 								return value.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var xLabels = getLabels(chart.scales['x-axis-0']);
-		var yLabels = getLabels(chart.scales['y-axis-0']);
+		var xLabels = getLabels(chart.scales.x);
+		var yLabels = getLabels(chart.scales.y);
 
 		expect(xLabels).toEqual(['0.1', '0.2', '0.3', '0.4', '0.5', '0.6', '0.7', '0.8', '0.9', '1']);
 		expect(yLabels).toEqual(['1', '0.9', '0.8', '0.7', '0.6', '0.5', '0.4', '0.3', '0.2', '0.1']);

--- a/test/specs/scale.category.tests.js
+++ b/test/specs/scale.category.tests.js
@@ -147,11 +147,10 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'x',
+					x: {
 						type: 'category',
 						labels: labels
-					}]
+					}
 				}
 			}
 		});
@@ -165,28 +164,26 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var scale = chart.scales.xScale0;
+		var scale = chart.scales.x;
 
 		expect(scale.getLabelForValue(1)).toBe('tick2');
 	});
@@ -196,28 +193,26 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick_last']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(0)).toBeCloseToPixel(23 + 6); // plus lineHeight
 		expect(xScale.getValueForPixel(23)).toBe(0);
 
@@ -239,28 +234,26 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick_last']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue('tick1')).toBeCloseToPixel(23 + 6); // plus lineHeight
 	});
 
@@ -269,30 +262,28 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick_last']
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom',
 						min: 'tick2',
 						max: 'tick4'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(1)).toBeCloseToPixel(23 + 6); // plus lineHeight
 		expect(xScale.getPixelForValue(3)).toBeCloseToPixel(496);
 
@@ -308,8 +299,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: ['3', '5', '1', '4', '2']
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
@@ -317,21 +308,19 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom',
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'category',
 						position: 'left'
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue(0)).toBeCloseToPixel(32);
 		expect(yScale.getValueForPixel(257)).toBe(2);
 
@@ -353,8 +342,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: ['3', '5', '1', '4', '2']
 				}],
 				labels: ['tick1', 'tick2', 'tick3', 'tick4', 'tick5'],
@@ -362,23 +351,21 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom',
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'category',
 						position: 'left',
 						min: '2',
 						max: '4'
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 
 		expect(yScale.getPixelForValue(1)).toBeCloseToPixel(32);
 		expect(yScale.getPixelForValue(3)).toBeCloseToPixel(482);
@@ -395,8 +382,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 0, y: 10},
 						{x: 1, y: 5},
@@ -409,20 +396,18 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(0)).toBeCloseToPixel(29);
 		expect(xScale.getPixelForValue(3)).toBeCloseToPixel(506);
 		expect(xScale.getPixelForValue(4)).toBeCloseToPixel(664);
@@ -433,8 +418,8 @@ describe('Category scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 0, y: 2},
 						{x: 1, y: 4},
@@ -448,21 +433,19 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'category',
 						position: 'left'
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue(0)).toBeCloseToPixel(32);
 		expect(yScale.getPixelForValue(4)).toBeCloseToPixel(481);
 	});
@@ -472,8 +455,8 @@ describe('Category scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 0, y: 10},
 						{x: 1, y: 5},
@@ -486,20 +469,18 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'category',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(0)).toBeCloseToPixel(89);
 		expect(xScale.getPixelForValue(3)).toBeCloseToPixel(449);
 		expect(xScale.getPixelForValue(4)).toBeCloseToPixel(569);
@@ -510,8 +491,8 @@ describe('Category scale tests', function() {
 			type: 'horizontalBar',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [
 						{x: 10, y: 0},
 						{x: 5, y: 1},
@@ -524,20 +505,18 @@ describe('Category scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'category'
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue(0)).toBeCloseToPixel(88);
 		expect(yScale.getPixelForValue(3)).toBeCloseToPixel(426);
 		expect(yScale.getPixelForValue(4)).toBeCloseToPixel(538);

--- a/test/specs/scale.linear.tests.js
+++ b/test/specs/scale.linear.tests.js
@@ -53,33 +53,33 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, -5, 78, -100]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: [-1000, 1000],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale1',
-						type: 'linear'
-					}]
+					},
+					y2: {
+						type: 'linear',
+						position: 'right',
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-100);
-		expect(chart.scales.yScale0.max).toBe(150);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-100);
+		expect(chart.scales.y.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min of string data values', function() {
@@ -87,33 +87,33 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['10', '5', '0', '-5', '78', '-100']
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: ['-1000', '1000'],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['150']
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale1',
-						type: 'linear'
-					}]
+					},
+					y2: {
+						type: 'linear',
+						position: 'right'
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-100);
-		expect(chart.scales.yScale0.max).toBe(150);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-100);
+		expect(chart.scales.y.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min when no values provided and suggested minimum and maximum are set', function() {
@@ -121,26 +121,25 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: []
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						suggestedMin: -10,
 						suggestedMax: 15
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-10);
-		expect(chart.scales.yScale0.max).toBe(15);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-10);
+		expect(chart.scales.y.max).toBe(15);
 	});
 
 	it('Should correctly determine the max & min data values ignoring hidden datasets', function() {
@@ -148,13 +147,13 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['10', '5', '0', '-5', '78', '-100']
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: ['-1000', '1000'],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['150'],
 					hidden: true
 				}],
@@ -162,20 +161,20 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}, {
-						id: 'yScale1',
+					},
+					y2: {
+						position: 'right',
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-100);
-		expect(chart.scales.yScale0.max).toBe(80);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-100);
+		expect(chart.scales.y.max).toBe(80);
 	});
 
 	it('Should correctly determine the max & min data values ignoring data that is NaN', function() {
@@ -183,30 +182,29 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [null, 90, NaN, undefined, 45, 30, Infinity, -Infinity]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.min).toBe(30);
-		expect(chart.scales.yScale0.max).toBe(90);
+		expect(chart.scales.y.min).toBe(30);
+		expect(chart.scales.y.max).toBe(90);
 
 		// Scale is now stacked
-		chart.scales.yScale0.options.stacked = true;
+		chart.scales.y.options.stacked = true;
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(90);
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(90);
 	});
 
 	it('Should correctly determine the max & min data values for small numbers', function() {
@@ -214,24 +212,23 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [-1e-8, 3e-8, -4e-8, 6e-8]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min * 1e8).toBeCloseTo(-4);
-		expect(chart.scales.yScale0.max * 1e8).toBeCloseTo(6);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min * 1e8).toBeCloseTo(-4);
+		expect(chart.scales.y.max * 1e8).toBeCloseTo(6);
 	});
 
 	it('Should correctly determine the max & min for scatter data', function() {
@@ -239,8 +236,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -258,24 +255,22 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.xScale0.min).toBe(-20);
-		expect(chart.scales.xScale0.max).toBe(100);
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(100);
+		expect(chart.scales.x.min).toBe(-20);
+		expect(chart.scales.x.max).toBe(100);
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(100);
 	});
 
 	it('Should correctly get the label for the given index', function() {
@@ -283,8 +278,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -302,21 +297,19 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.yScale0.getLabelForValue(7)).toBe(7);
+		expect(chart.scales.y.getLabelForValue(7)).toBe(7);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on', function() {
@@ -324,18 +317,18 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, -5, 78, -100],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: [-1000, 1000],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 0, 0, -100, -10, 9],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 10, 10, 10, 10, 10],
 					type: 'line'
 				}],
@@ -343,21 +336,21 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y2: {
+						position: 'right',
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(-150);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(-150);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on and there are hidden datasets', function() {
@@ -365,16 +358,16 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, -5, 78, -100],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y2',
 					data: [-1000, 1000],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 0, 0, -100, -10, 9],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 20, 30, 40, 50, 60],
 					hidden: true
 				}],
@@ -382,21 +375,21 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y2: {
+						position: 'right',
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(-150);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(-150);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('Should correctly determine the min and max data values when stacked mode is turned on there are multiple types of datasets', function() {
@@ -404,7 +397,7 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					type: 'bar',
 					data: [10, 5, 0, -5, 78, -100]
 				}, {
@@ -418,18 +411,17 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
 
-		chart.scales.yScale0.determineDataLimits();
-		expect(chart.scales.yScale0.min).toBe(-105);
-		expect(chart.scales.yScale0.max).toBe(160);
+		chart.scales.y.determineDataLimits();
+		expect(chart.scales.y.min).toBe(-105);
+		expect(chart.scales.y.max).toBe(160);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal', function() {
@@ -441,17 +433,16 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(1);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(1);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal when beginAtZero is set', function() {
@@ -463,18 +454,17 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						beginAtZero: true
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(1);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(1);
 	});
 
 	it('Should use the suggestedMin and suggestedMax options', function() {
@@ -482,26 +472,25 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [1, 1, 1, 2, 1, 0]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						suggestedMax: 10,
 						suggestedMin: -10
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-10);
-		expect(chart.scales.yScale0.max).toBe(10);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-10);
+		expect(chart.scales.y.max).toBe(10);
 	});
 
 	it('Should use the min and max options', function() {
@@ -509,27 +498,26 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [1, 1, 1, 2, 1, 0]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						max: 1010,
 						min: -1010
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(-1010);
-		expect(chart.scales.yScale0.max).toBe(1010);
-		var labels = getLabels(chart.scales.yScale0);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(-1010);
+		expect(chart.scales.y.max).toBe(1010);
+		var labels = getLabels(chart.scales.y);
 		expect(labels[0]).toBe('1010');
 		expect(labels[labels.length - 1]).toBe('-1010');
 	});
@@ -539,30 +527,29 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 3, 6, 8, 3, 1]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						min: 1,
 						max: 11,
 						ticks: {
 							stepSize: 2
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(1);
-		expect(chart.scales.yScale0.max).toBe(11);
-		expect(getLabels(chart.scales.yScale0)).toEqual(['11', '10', '8', '6', '4', '2', '1']);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(11);
+		expect(getLabels(chart.scales.y)).toEqual(['11', '10', '8', '6', '4', '2', '1']);
 	});
 
 	it('Should create decimal steps if stepSize is a decimal number', function() {
@@ -570,28 +557,27 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 3, 6, 8, 3, 1]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							stepSize: 2.5
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(0);
-		expect(chart.scales.yScale0.max).toBe(10);
-		expect(getLabels(chart.scales.yScale0)).toEqual(['10', '7.5', '5', '2.5', '0']);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(10);
+		expect(getLabels(chart.scales.y)).toEqual(['10', '7.5', '5', '2.5', '0']);
 	});
 
 	describe('precision', function() {
@@ -600,28 +586,27 @@ describe('Linear Scale', function() {
 				type: 'bar',
 				data: {
 					datasets: [{
-						yAxisID: 'yScale0',
+						yAxisID: 'y',
 						data: [0, 1, 2, 1, 0, 1]
 					}],
 					labels: ['a', 'b', 'c', 'd', 'e', 'f']
 				},
 				options: {
 					scales: {
-						yAxes: [{
-							id: 'yScale0',
+						y: {
 							type: 'linear',
 							ticks: {
 								precision: 0
 							}
-						}]
+						}
 					}
 				}
 			});
 
-			expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-			expect(chart.scales.yScale0.min).toBe(0);
-			expect(chart.scales.yScale0.max).toBe(2);
-			expect(getLabels(chart.scales.yScale0)).toEqual(['2', '1', '0']);
+			expect(chart.scales.y).not.toEqual(undefined); // must construct
+			expect(chart.scales.y.min).toBe(0);
+			expect(chart.scales.y.max).toBe(2);
+			expect(getLabels(chart.scales.y)).toEqual(['2', '1', '0']);
 		});
 
 		it('Should round the step size to the given number of decimal places', function() {
@@ -629,28 +614,27 @@ describe('Linear Scale', function() {
 				type: 'bar',
 				data: {
 					datasets: [{
-						yAxisID: 'yScale0',
+						yAxisID: 'y',
 						data: [0, 0.001, 0.002, 0.003, 0, 0.001]
 					}],
 					labels: ['a', 'b', 'c', 'd', 'e', 'f']
 				},
 				options: {
 					scales: {
-						yAxes: [{
-							id: 'yScale0',
+						y: {
 							type: 'linear',
 							ticks: {
 								precision: 2
 							}
-						}]
+						}
 					}
 				}
 			});
 
-			expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-			expect(chart.scales.yScale0.min).toBe(0);
-			expect(chart.scales.yScale0.max).toBe(0.01);
-			expect(getLabels(chart.scales.yScale0)).toEqual(['0.01', '0']);
+			expect(chart.scales.y).not.toEqual(undefined); // must construct
+			expect(chart.scales.y.min).toBe(0);
+			expect(chart.scales.y.max).toBe(0.01);
+			expect(getLabels(chart.scales.y)).toEqual(['0.01', '0']);
 		});
 	});
 
@@ -660,35 +644,34 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [20, 30, 40, 50]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(getLabels(chart.scales.yScale0)).toEqual(['50', '45', '40', '35', '30', '25', '20']);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(getLabels(chart.scales.y)).toEqual(['50', '45', '40', '35', '30', '25', '20']);
 
-		chart.scales.yScale0.options.beginAtZero = true;
+		chart.scales.y.options.beginAtZero = true;
 		chart.update();
-		expect(getLabels(chart.scales.yScale0)).toEqual(['50', '45', '40', '35', '30', '25', '20', '15', '10', '5', '0']);
+		expect(getLabels(chart.scales.y)).toEqual(['50', '45', '40', '35', '30', '25', '20', '15', '10', '5', '0']);
 
 		chart.data.datasets[0].data = [-20, -30, -40, -50];
 		chart.update();
-		expect(getLabels(chart.scales.yScale0)).toEqual(['0', '-5', '-10', '-15', '-20', '-25', '-30', '-35', '-40', '-45', '-50']);
+		expect(getLabels(chart.scales.y)).toEqual(['0', '-5', '-10', '-15', '-20', '-25', '-30', '-35', '-40', '-45', '-50']);
 
-		chart.scales.yScale0.options.beginAtZero = false;
+		chart.scales.y.options.beginAtZero = false;
 		chart.update();
-		expect(getLabels(chart.scales.yScale0)).toEqual(['-20', '-25', '-30', '-35', '-40', '-45', '-50']);
+		expect(getLabels(chart.scales.y)).toEqual(['-20', '-25', '-30', '-35', '-40', '-45', '-50']);
 	});
 
 	it('Should generate tick marks in the correct order in reversed mode', function() {
@@ -696,25 +679,24 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						reverse: true
-					}]
+					}
 				}
 			}
 		});
 
-		expect(getLabels(chart.scales.yScale0)).toEqual(['0', '10', '20', '30', '40', '50', '60', '70', '80']);
-		expect(chart.scales.yScale0.start).toBe(80);
-		expect(chart.scales.yScale0.end).toBe(0);
+		expect(getLabels(chart.scales.y)).toEqual(['0', '10', '20', '30', '40', '50', '60', '70', '80']);
+		expect(chart.scales.y.start).toBe(80);
+		expect(chart.scales.y.end).toBe(0);
 	});
 
 	it('should use the correct number of decimal places in the default format function', function() {
@@ -722,21 +704,20 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [0.06, 0.005, 0, 0.025, 0.0078]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
-		expect(getLabels(chart.scales.yScale0)).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
+		expect(getLabels(chart.scales.y)).toEqual(['0.06', '0.05', '0.04', '0.03', '0.02', '0.01', '0']);
 	});
 
 	it('Should correctly limit the maximum number of ticks', function() {
@@ -750,40 +731,38 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale'
-					}]
+					y: {}
 				}
 			}
 		});
 
-		expect(getLabels(chart.scales.yScale)).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+		expect(getLabels(chart.scales.y)).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
 
-		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 11;
+		chart.options.scales.y.ticks.maxTicksLimit = 11;
 		chart.update();
 
-		expect(getLabels(chart.scales.yScale)).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+		expect(getLabels(chart.scales.y)).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
 
-		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 21;
+		chart.options.scales.y.ticks.maxTicksLimit = 21;
 		chart.update();
 
-		expect(getLabels(chart.scales.yScale)).toEqual([
+		expect(getLabels(chart.scales.y)).toEqual([
 			'2.5', '2.4', '2.3', '2.2', '2.1', '2.0', '1.9', '1.8', '1.7', '1.6',
 			'1.5', '1.4', '1.3', '1.2', '1.1', '1.0', '0.9', '0.8', '0.7', '0.6',
 			'0.5'
 		]);
 
-		chart.options.scales.yAxes[0].ticks.maxTicksLimit = 11;
-		chart.options.scales.yAxes[0].ticks.stepSize = 0.01;
+		chart.options.scales.y.ticks.maxTicksLimit = 11;
+		chart.options.scales.y.ticks.stepSize = 0.01;
 		chart.update();
 
-		expect(getLabels(chart.scales.yScale)).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
+		expect(getLabels(chart.scales.y)).toEqual(['2.5', '2.0', '1.5', '1.0', '0.5']);
 
-		chart.options.scales.yAxes[0].min = 0.3;
-		chart.options.scales.yAxes[0].max = 2.8;
+		chart.options.scales.y.min = 0.3;
+		chart.options.scales.y.max = 2.8;
 		chart.update();
 
-		expect(getLabels(chart.scales.yScale)).toEqual(['2.8', '2.5', '2.0', '1.5', '1.0', '0.5', '0.3']);
+		expect(getLabels(chart.scales.y)).toEqual(['2.8', '2.5', '2.0', '1.5', '1.0', '0.5', '0.3']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {
@@ -791,28 +770,27 @@ describe('Linear Scale', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 0, 25, 78]
 				}],
 				labels: ['a', 'b', 'c', 'd']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
 						ticks: {
 							callback: function(value, index) {
 								return index.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Just the index
-		expect(getLabels(chart.scales.yScale0)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
+		expect(getLabels(chart.scales.y)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
 	});
 
 	it('Should get the correct pixel value for a point', function() {
@@ -821,27 +799,25 @@ describe('Linear Scale', function() {
 			data: {
 				labels: [-1, 1],
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [-1, 1]
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		expect(xScale.getPixelForValue(1)).toBeCloseToPixel(501); // right - paddingRight
 		expect(xScale.getPixelForValue(-1)).toBeCloseToPixel(31 + 6); // left + paddingLeft + lineSpace
 		expect(xScale.getPixelForValue(0)).toBeCloseToPixel(266 + 6 / 2); // halfway*/
@@ -850,7 +826,7 @@ describe('Linear Scale', function() {
 		expect(xScale.getValueForPixel(31)).toBeCloseTo(-1, 1e-2);
 		expect(xScale.getValueForPixel(266)).toBeCloseTo(0, 1e-2);
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.getPixelForValue(1)).toBeCloseToPixel(32); // right - paddingRight
 		expect(yScale.getPixelForValue(-1)).toBeCloseToPixel(484); // left + paddingLeft
 		expect(yScale.getPixelForValue(0)).toBeCloseToPixel(258); // halfway*/
@@ -865,8 +841,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -884,21 +860,19 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
-		var yScale = chart.scales.yScale0;
+		var xScale = chart.scales.x;
+		var yScale = chart.scales.y;
 		expect(xScale.paddingTop).toBeCloseToPixel(0);
 		expect(xScale.paddingBottom).toBeCloseToPixel(0);
 		expect(xScale.paddingLeft).toBeCloseToPixel(12);
@@ -938,8 +912,8 @@ describe('Linear Scale', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
-					yAxisID: 'yScale0',
+					xAxisID: 'x',
+					yAxisID: 'y',
 					data: [{
 						x: 10,
 						y: 100
@@ -957,13 +931,11 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'linear',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale0',
+					},
+					y: {
 						type: 'linear',
 						gridLines: {
 							drawTicks: false,
@@ -977,12 +949,12 @@ describe('Linear Scale', function() {
 							display: false,
 							padding: 0
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale0;
+		var yScale = chart.scales.y;
 		expect(yScale.width).toBeCloseToPixel(0);
 	});
 
@@ -1009,12 +981,12 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						stacked: true
-					}],
-					yAxes: [{
+					},
+					y: {
 						stacked: true
-					}]
+					}
 				}
 			}
 		});
@@ -1025,8 +997,8 @@ describe('Linear Scale', function() {
 			chart.update();
 		});
 
-		expect(chart.scales['x-axis-0'].min).toEqual(0);
-		expect(chart.scales['x-axis-0'].max).toEqual(1);
+		expect(chart.scales.x.min).toEqual(0);
+		expect(chart.scales.x.max).toEqual(1);
 	});
 
 	it('max and min value should be valid when min is set and all datasets are hidden', function() {
@@ -1045,15 +1017,15 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						min: 20
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales['x-axis-0'].min).toEqual(20);
-		expect(chart.scales['x-axis-0'].max).toEqual(21);
+		expect(chart.scales.x.min).toEqual(20);
+		expect(chart.scales.x.max).toEqual(21);
 	});
 
 	it('min settings should be used if set to zero', function() {
@@ -1071,15 +1043,15 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						min: 0,
 						max: 3000
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales['x-axis-0'].min).toEqual(0);
+		expect(chart.scales.x.min).toEqual(0);
 	});
 
 	it('max settings should be used if set to zero', function() {
@@ -1097,15 +1069,15 @@ describe('Linear Scale', function() {
 			data: barData,
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						min: -3000,
 						max: 0
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales['x-axis-0'].max).toEqual(0);
+		expect(chart.scales.x.max).toEqual(0);
 	});
 
 	it('Should generate max and min that are not equal when data contains values that are very close to each other', function() {
@@ -1121,16 +1093,15 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.max).toBeGreaterThan(chart.scales.yScale0.min);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.max).toBeGreaterThan(chart.scales.y.min);
 	});
 
 	it('Should get correct pixel values when horizontal', function() {
@@ -1143,10 +1114,9 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'x',
+					x: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});
@@ -1184,10 +1154,9 @@ describe('Linear Scale', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'y',
+					y: {
 						type: 'linear',
-					}]
+					}
 				}
 			}
 		});

--- a/test/specs/scale.logarithmic.tests.js
+++ b/test/specs/scale.logarithmic.tests.js
@@ -54,57 +54,60 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [42, 1000, 64, 100],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [10, 5, 5000, 78, 450]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [150]
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [20, 0, 150, 1800, 3040]
 				}, {
-					yAxisID: 'yScale3',
+					yAxisID: 'y3',
 					data: [67, 0.0004, 0, 820, 0.001]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
+						id: 'y',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						type: 'logarithmic',
+						position: 'right'
+					},
+					y2: {
+						type: 'logarithmic',
+						position: 'right'
+					},
+					y3: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale2',
-						type: 'logarithmic'
-					}, {
-						id: 'yScale3',
-						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(1000);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(1000);
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(1);
-		expect(chart.scales.yScale1.max).toBe(5000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(1);
+		expect(chart.scales.y1.max).toBe(5000);
 
-		expect(chart.scales.yScale2).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale2.min).toBe(0);
-		expect(chart.scales.yScale2.max).toBe(4000);
+		expect(chart.scales.y2).not.toEqual(undefined); // must construct
+		expect(chart.scales.y2.min).toBe(0);
+		expect(chart.scales.y2.max).toBe(4000);
 
-		expect(chart.scales.yScale3).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale3.min).toBe(0);
-		expect(chart.scales.yScale3.max).toBe(900);
+		expect(chart.scales.y3).not.toEqual(undefined); // must construct
+		expect(chart.scales.y3.min).toBe(0);
+		expect(chart.scales.y3.max).toBe(900);
 	});
 
 	it('should correctly determine the max & min of string data values', function() {
@@ -112,57 +115,59 @@ describe('Logarithmic Scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: ['42', '1000', '64', '100'],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: ['10', '5', '5000', '78', '450']
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: ['150']
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: ['20', '0', '150', '1800', '3040']
 				}, {
-					yAxisID: 'yScale3',
+					yAxisID: 'y3',
 					data: ['67', '0.0004', '0', '820', '0.001']
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale2',
+					},
+					y2: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale3',
+					},
+					y3: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(1000);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(1000);
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(1);
-		expect(chart.scales.yScale1.max).toBe(5000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(1);
+		expect(chart.scales.y1.max).toBe(5000);
 
-		expect(chart.scales.yScale2).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale2.min).toBe(0);
-		expect(chart.scales.yScale2.max).toBe(4000);
+		expect(chart.scales.y2).not.toEqual(undefined); // must construct
+		expect(chart.scales.y2.min).toBe(0);
+		expect(chart.scales.y2.max).toBe(4000);
 
-		expect(chart.scales.yScale3).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale3.min).toBe(0);
-		expect(chart.scales.yScale3.max).toBe(900);
+		expect(chart.scales.y3).not.toEqual(undefined); // must construct
+		expect(chart.scales.y3.min).toBe(0);
+		expect(chart.scales.y3.max).toBe(900);
 	});
 
 	it('should correctly determine the max & min data values when there are hidden datasets', function() {
@@ -170,20 +175,20 @@ describe('Logarithmic Scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [10, 5, 5000, 78, 450]
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [42, 1000, 64, 100],
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [50000],
 					hidden: true
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [20, 0, 7400, 14, 291]
 				}, {
-					yAxisID: 'yScale2',
+					yAxisID: 'y2',
 					data: [6, 0.0007, 9, 890, 60000],
 					hidden: true
 				}],
@@ -191,27 +196,28 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}, {
-						id: 'yScale2',
+					},
+					y2: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(1);
-		expect(chart.scales.yScale1.max).toBe(5000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(1);
+		expect(chart.scales.y1.max).toBe(5000);
 
-		expect(chart.scales.yScale2).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale2.min).toBe(0);
-		expect(chart.scales.yScale2.max).toBe(8000);
+		expect(chart.scales.y2).not.toEqual(undefined); // must construct
+		expect(chart.scales.y2.min).toBe(0);
+		expect(chart.scales.y2.max).toBe(8000);
 	});
 
 	it('should correctly determine the max & min data values when there is NaN data', function() {
@@ -219,47 +225,47 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [undefined, 10, null, 5, 5000, NaN, 78, 450]
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [undefined, 28, null, 1000, 500, NaN, 50, 42, Infinity, -Infinity]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [undefined, 30, null, 9400, 0, NaN, 54, 836]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [undefined, 0, null, 800, 9, NaN, 894, 21]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale0.min).toBe(1);
-		expect(chart.scales.yScale0.max).toBe(5000);
+		expect(chart.scales.y).not.toEqual(undefined); // must construct
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(5000);
 
 		// Turn on stacked mode since it uses it's own
-		chart.options.scales.yAxes[0].stacked = true;
+		chart.options.scales.y.stacked = true;
 		chart.update();
 
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(6000);
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(6000);
 
-		expect(chart.scales.yScale1).not.toEqual(undefined); // must construct
-		expect(chart.scales.yScale1.min).toBe(0);
-		expect(chart.scales.yScale1.max).toBe(10000);
+		expect(chart.scales.y1).not.toEqual(undefined); // must construct
+		expect(chart.scales.y1.min).toBe(0);
+		expect(chart.scales.y1.max).toBe(10000);
 	});
 
 	it('should correctly determine the max & min for scatter data', function() {
@@ -277,24 +283,22 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'logarithmic',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.xScale.min).toBe(1);
-		expect(chart.scales.xScale.max).toBe(100);
+		expect(chart.scales.x.min).toBe(1);
+		expect(chart.scales.x.max).toBe(100);
 
-		expect(chart.scales.yScale.min).toBe(1);
-		expect(chart.scales.yScale.max).toBe(200);
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('should correctly determine the max & min for scatter data when 0 values are present', function() {
@@ -312,24 +316,22 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale',
+					x: {
 						type: 'logarithmic',
 						position: 'bottom'
-					}],
-					yAxes: [{
-						id: 'yScale',
+					},
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.xScale.min).toBe(0);
-		expect(chart.scales.xScale.max).toBe(300);
+		expect(chart.scales.x.min).toBe(0);
+		expect(chart.scales.x.max).toBe(300);
 
-		expect(chart.scales.yScale.min).toBe(0);
-		expect(chart.scales.yScale.max).toBe(1000);
+		expect(chart.scales.y.min).toBe(0);
+		expect(chart.scales.y.max).toBe(1000);
 	});
 
 	it('should correctly determine the min and max data values when stacked mode is turned on', function() {
@@ -338,38 +340,38 @@ describe('Logarithmic Scale tests', function() {
 			data: {
 				datasets: [{
 					type: 'bar',
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 1, 5, 78, 100]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [0, 1000],
 				}, {
 					type: 'bar',
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 10, 10, 100, 10, 9]
 				}, {
 					type: 'line',
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [100, 100, 100, 100, 100, 100]
 				}],
 				labels: ['a', 'b', 'c', 'd', 'e', 'f']
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('should correctly determine the min and max data values when stacked mode is turned on ignoring hidden datasets', function() {
@@ -377,19 +379,19 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 1, 5, 78, 100],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [0, 1000],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150, 10, 10, 100, 10, 9],
 					type: 'bar'
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10000, 10000, 10000, 10000, 10000, 10000],
 					hidden: true,
 					type: 'bar'
@@ -398,20 +400,20 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic',
 						stacked: true
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.min).toBe(10);
-		expect(chart.scales.yScale0.max).toBe(200);
+		expect(chart.scales.y.min).toBe(10);
+		expect(chart.scales.y.max).toBe(200);
 	});
 
 	it('should ensure that the scale has a max and min that are not equal', function() {
@@ -425,22 +427,21 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale.min).toBe(1);
-		expect(chart.scales.yScale.max).toBe(10);
+		expect(chart.scales.y.min).toBe(1);
+		expect(chart.scales.y.max).toBe(10);
 
 		chart.data.datasets[0].data = [0.15, 0.15];
 		chart.update();
 
-		expect(chart.scales.yScale.min).toBe(0.01);
-		expect(chart.scales.yScale.max).toBe(1);
+		expect(chart.scales.y.min).toBe(0.01);
+		expect(chart.scales.y.max).toBe(1);
 	});
 
 	it('should use the min and max options', function() {
@@ -454,8 +455,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						min: 10,
 						max: 1010,
@@ -464,12 +464,12 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale;
+		var yScale = chart.scales.y;
 		var tickCount = yScale.ticks.length;
 		expect(yScale.min).toBe(10);
 		expect(yScale.max).toBe(1010);
@@ -488,8 +488,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						min: -10,
 						max: -1010,
@@ -498,14 +497,14 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale;
-		expect(yScale.min).toBe(0);
-		expect(yScale.max).toBe(2);
+		var y = chart.scales.y;
+		expect(y.min).toBe(0);
+		expect(y.max).toBe(2);
 	});
 
 	it('should ignore invalid min and max options', function() {
@@ -519,8 +518,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						min: 'zero',
 						max: null,
@@ -529,14 +527,14 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var yScale = chart.scales.yScale;
-		expect(yScale.min).toBe(0);
-		expect(yScale.max).toBe(2);
+		var y = chart.scales.y;
+		expect(y.min).toBe(0);
+		expect(y.max).toBe(2);
 	});
 
 	it('should generate tick marks', function() {
@@ -550,21 +548,20 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							callback: function(value) {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		var scale = chart.scales.yScale;
+		var scale = chart.scales.y;
 		expect(getLabels(scale)).toEqual([80, 70, 60, 50, 40, 30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
 		expect(scale.start).toEqual(1);
 		expect(scale.end).toEqual(80);
@@ -581,20 +578,19 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							callback: function(value) {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var scale = chart.scales.yScale;
+		var scale = chart.scales.y;
 		// Counts down because the lines are drawn top to bottom
 		expect(getLabels(scale)).toEqual([30, 20, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0.9, 0.8, 0]);
 		expect(scale.start).toEqual(0);
@@ -613,8 +609,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						reverse: true,
 						ticks: {
@@ -622,12 +617,12 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var scale = chart.scales.yScale;
+		var scale = chart.scales.y;
 		expect(getLabels(scale)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 30, 40, 50, 60, 70, 80]);
 		expect(scale.start).toEqual(80);
 		expect(scale.end).toEqual(1);
@@ -644,8 +639,7 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						reverse: true,
 						ticks: {
@@ -653,12 +647,12 @@ describe('Logarithmic Scale tests', function() {
 								return value;
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		var scale = chart.scales.yScale;
+		var scale = chart.scales.y;
 		expect(getLabels(scale)).toEqual([0, 9, 10, 20, 30]);
 		expect(scale.start).toEqual(30);
 		expect(scale.end).toEqual(0);
@@ -675,15 +669,14 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(getLabels(chart.scales.yScale)).toEqual(['8e+1', '', '', '5e+1', '', '', '2e+1', '1e+1', '', '', '', '', '5e+0', '', '', '2e+0', '1e+0', '0']);
+		expect(getLabels(chart.scales.y)).toEqual(['8e+1', '', '', '5e+1', '', '', '2e+1', '1e+1', '', '', '', '', '5e+0', '', '', '2e+0', '1e+0', '0']);
 	});
 
 	it('should build labels using the user supplied callback', function() {
@@ -697,21 +690,20 @@ describe('Logarithmic Scale tests', function() {
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale',
+					y: {
 						type: 'logarithmic',
 						ticks: {
 							callback: function(value, index) {
 								return index.toString();
 							}
 						}
-					}]
+					}
 				}
 			}
 		});
 
 		// Just the index
-		expect(getLabels(chart.scales.yScale)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16']);
+		expect(getLabels(chart.scales.y)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16']);
 	});
 
 	it('should correctly get the correct label for a data item', function() {
@@ -719,31 +711,31 @@ describe('Logarithmic Scale tests', function() {
 			type: 'bar',
 			data: {
 				datasets: [{
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [10, 5, 5000, 78, 450]
 				}, {
-					yAxisID: 'yScale1',
+					yAxisID: 'y1',
 					data: [1, 1000, 10, 100],
 				}, {
-					yAxisID: 'yScale0',
+					yAxisID: 'y',
 					data: [150]
 				}],
 				labels: []
 			},
 			options: {
 				scales: {
-					yAxes: [{
-						id: 'yScale0',
+					y: {
 						type: 'logarithmic'
-					}, {
-						id: 'yScale1',
+					},
+					y1: {
+						position: 'right',
 						type: 'logarithmic'
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.yScale0.getLabelForValue(150)).toBe(150);
+		expect(chart.scales.y.getLabelForValue(150)).toBe(150);
 	});
 
 	describe('when', function() {
@@ -780,9 +772,9 @@ describe('Logarithmic Scale tests', function() {
 			{
 				axis: 'y',
 				scale: {
-					yAxes: [{
+					y: {
 						min: 0
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'all stacks are defined and min: 0'
@@ -791,9 +783,9 @@ describe('Logarithmic Scale tests', function() {
 				axis: 'y',
 				data: dataWithEmptyStacks,
 				scale: {
-					yAxes: [{
+					y: {
 						min: 0
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'not stacks are defined and min: 0'
@@ -812,9 +804,9 @@ describe('Logarithmic Scale tests', function() {
 			{
 				axis: 'x',
 				scale: {
-					xAxes: [{
+					x: {
 						min: 0
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'all stacks are defined and min: 0'
@@ -823,9 +815,9 @@ describe('Logarithmic Scale tests', function() {
 				axis: 'x',
 				data: dataWithEmptyStacks,
 				scale: {
-					xAxes: [{
+					x: {
 						min: 0
-					}]
+					}
 				},
 				firstTick: 0,
 				describe: 'not all stacks are defined and min: 0'
@@ -844,11 +836,11 @@ describe('Logarithmic Scale tests', function() {
 				chartStart = 'bottom';
 				chartEnd = 'top';
 			}
-			scaleConfig[setup.axis + 'Axes'] = [{
+			scaleConfig[setup.axis] = {
 				type: 'logarithmic'
-			}];
+			};
 			Chart.helpers.extend(scaleConfig, setup.scale);
-			scaleConfig[setup.axis + 'Axes'][0].type = 'logarithmic';
+			scaleConfig[setup.axis].type = 'logarithmic';
 
 			var description = 'dataset has stack option and ' + setup.describe
 				+ ' and axis is "' + setup.axis + '";';
@@ -865,7 +857,7 @@ describe('Logarithmic Scale tests', function() {
 						}
 					});
 
-					var axisID = setup.axis + '-axis-0';
+					var axisID = setup.axis;
 					var scale = chart.scales[axisID];
 					var firstTick = setup.firstTick;
 					var lastTick = 80; // last tick (should be first available tick after: 2 * 39)
@@ -979,27 +971,29 @@ describe('Logarithmic Scale tests', function() {
 				var expectation = 'min = ' + setup.firstTick + ', max = ' + setup.lastTick;
 				describe(setup.describe + ' and axis is "' + axis.id + '"; expect: ' + expectation + ';', function() {
 					beforeEach(function() {
-						var xScaleConfig = {
+						var xConfig = {
 							type: 'logarithmic',
+							position: 'bottom'
 						};
-						var yScaleConfig = {
+						var yConfig = {
 							type: 'logarithmic',
+							position: 'left'
 						};
 						var data = setup.data || {
 							datasets: [{
 								data: setup.dataset
 							}],
 						};
-						Chart.helpers.extend(xScaleConfig, setup.scale);
-						Chart.helpers.extend(yScaleConfig, setup.scale);
+						Chart.helpers.extend(xConfig, setup.scale);
+						Chart.helpers.extend(yConfig, setup.scale);
 						Chart.helpers.extend(data, setup.data || {});
 						this.chart = window.acquireChart({
 							type: 'line',
 							data: data,
 							options: {
 								scales: {
-									xAxes: [xScaleConfig],
-									yAxes: [yScaleConfig]
+									x: xConfig,
+									y: yConfig
 								}
 							}
 						});
@@ -1007,7 +1001,7 @@ describe('Logarithmic Scale tests', function() {
 
 					it('should get the correct pixel value for a point', function() {
 						var chart = this.chart;
-						var axisID = axis.id + '-axis-0';
+						var axisID = axis.id;
 						var scale = chart.scales[axisID];
 						var firstTick = setup.firstTick;
 						var lastTick = setup.lastTick;
@@ -1106,27 +1100,29 @@ describe('Logarithmic Scale tests', function() {
 				var expectation = 'min = 0, max = ' + setup.lastTick + ', first tick = ' + setup.firstTick;
 				describe(setup.describe + ' and axis is "' + axis.id + '"; expect: ' + expectation + ';', function() {
 					beforeEach(function() {
-						var xScaleConfig = {
+						var xConfig = {
 							type: 'logarithmic',
+							position: 'bottom'
 						};
-						var yScaleConfig = {
+						var yConfig = {
 							type: 'logarithmic',
+							position: 'left'
 						};
 						var data = setup.data || {
 							datasets: [{
 								data: setup.dataset
 							}],
 						};
-						Chart.helpers.extend(xScaleConfig, setup.scale);
-						Chart.helpers.extend(yScaleConfig, setup.scale);
+						Chart.helpers.extend(xConfig, setup.scale);
+						Chart.helpers.extend(yConfig, setup.scale);
 						Chart.helpers.extend(data, setup.data || {});
 						this.chart = window.acquireChart({
 							type: 'line',
 							data: data,
 							options: {
 								scales: {
-									xAxes: [xScaleConfig],
-									yAxes: [yScaleConfig]
+									x: xConfig,
+									y: yConfig
 								}
 							}
 						});
@@ -1134,7 +1130,7 @@ describe('Logarithmic Scale tests', function() {
 
 					it('should get the correct pixel value for a point', function() {
 						var chart = this.chart;
-						var axisID = axis.id + '-axis-0';
+						var axisID = axis.id;
 						var scale = chart.scales[axisID];
 						var firstTick = setup.firstTick;
 						var lastTick = setup.lastTick;

--- a/test/specs/scale.radialLinear.tests.js
+++ b/test/specs/scale.radialLinear.tests.js
@@ -87,8 +87,8 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.min).toBe(-100);
-		expect(chart.scale.max).toBe(150);
+		expect(chart.scales.r.min).toBe(-100);
+		expect(chart.scales.r.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min of string data values', function() {
@@ -107,8 +107,8 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.min).toBe(-100);
-		expect(chart.scale.max).toBe(150);
+		expect(chart.scales.r.min).toBe(-100);
+		expect(chart.scales.r.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min data values when there are hidden datasets', function() {
@@ -130,8 +130,8 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.min).toBe(-100);
-		expect(chart.scale.max).toBe(150);
+		expect(chart.scales.r.min).toBe(-100);
+		expect(chart.scales.r.max).toBe(150);
 	});
 
 	it('Should correctly determine the max & min data values when there is NaN data', function() {
@@ -148,8 +148,8 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.min).toBe(50);
-		expect(chart.scale.max).toBe(70);
+		expect(chart.scales.r.min).toBe(50);
+		expect(chart.scales.r.max).toBe(70);
 	});
 
 	it('Should ensure that the scale has a max and min that are not equal', function() {
@@ -160,13 +160,13 @@ describe('Test the radial linear scale', function() {
 				labels: []
 			},
 			options: {
-				scale: {
-					id: 'myScale'
+				scales: {
+					rScale: {}
 				}
 			}
 		});
 
-		var scale = chart.scales.myScale;
+		var scale = chart.scales.rScale;
 
 		expect(scale.min).toBe(-1);
 		expect(scale.max).toBe(1);
@@ -189,8 +189,8 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.min).toBe(-10);
-		expect(chart.scale.max).toBe(10);
+		expect(chart.scales.r.min).toBe(-10);
+		expect(chart.scales.r.max).toBe(10);
 	});
 
 	it('Should use the min and max options', function() {
@@ -210,9 +210,9 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.min).toBe(-1010);
-		expect(chart.scale.max).toBe(1010);
-		expect(getLabels(chart.scale)).toEqual(['-1010', '-1000', '-500', '0', '500', '1000', '1010']);
+		expect(chart.scales.r.min).toBe(-1010);
+		expect(chart.scales.r.max).toBe(1010);
+		expect(getLabels(chart.scales.r)).toEqual(['-1010', '-1000', '-500', '0', '500', '1000', '1010']);
 	});
 
 	it('should forcibly include 0 in the range if the beginAtZero option is used', function() {
@@ -231,22 +231,22 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(getLabels(chart.scale)).toEqual(['20', '25', '30', '35', '40', '45', '50']);
+		expect(getLabels(chart.scales.r)).toEqual(['20', '25', '30', '35', '40', '45', '50']);
 
-		chart.scale.options.beginAtZero = true;
+		chart.scales.r.options.beginAtZero = true;
 		chart.update();
 
-		expect(getLabels(chart.scale)).toEqual(['0', '5', '10', '15', '20', '25', '30', '35', '40', '45', '50']);
+		expect(getLabels(chart.scales.r)).toEqual(['0', '5', '10', '15', '20', '25', '30', '35', '40', '45', '50']);
 
 		chart.data.datasets[0].data = [-20, -30, -40, -50];
 		chart.update();
 
-		expect(getLabels(chart.scale)).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20', '-15', '-10', '-5', '0']);
+		expect(getLabels(chart.scales.r)).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20', '-15', '-10', '-5', '0']);
 
-		chart.scale.options.beginAtZero = false;
+		chart.scales.r.options.beginAtZero = false;
 		chart.update();
 
-		expect(getLabels(chart.scale)).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20']);
+		expect(getLabels(chart.scales.r)).toEqual(['-50', '-45', '-40', '-35', '-30', '-25', '-20']);
 	});
 
 	it('Should generate tick marks in the correct order in reversed mode', function() {
@@ -265,9 +265,9 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(getLabels(chart.scale)).toEqual(['80', '70', '60', '50', '40', '30', '20', '10', '0']);
-		expect(chart.scale.start).toBe(80);
-		expect(chart.scale.end).toBe(0);
+		expect(getLabels(chart.scales.r)).toEqual(['80', '70', '60', '50', '40', '30', '20', '10', '0']);
+		expect(chart.scales.r.start).toBe(80);
+		expect(chart.scales.r.end).toBe(0);
 	});
 
 	it('Should correctly limit the maximum number of ticks', function() {
@@ -288,23 +288,23 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(getLabels(chart.scale)).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
+		expect(getLabels(chart.scales.r)).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
 
-		chart.options.scale.ticks.maxTicksLimit = 11;
+		chart.options.scales.r.ticks.maxTicksLimit = 11;
 		chart.update();
 
-		expect(getLabels(chart.scale)).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
+		expect(getLabels(chart.scales.r)).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
 
-		chart.options.scale.ticks.stepSize = 0.01;
+		chart.options.scales.r.ticks.stepSize = 0.01;
 		chart.update();
 
-		expect(getLabels(chart.scale)).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
+		expect(getLabels(chart.scales.r)).toEqual(['0.5', '1.0', '1.5', '2.0', '2.5']);
 
-		chart.options.scale.min = 0.3;
-		chart.options.scale.max = 2.8;
+		chart.options.scales.r.min = 0.3;
+		chart.options.scales.r.max = 2.8;
 		chart.update();
 
-		expect(getLabels(chart.scale)).toEqual(['0.3', '0.5', '1.0', '1.5', '2.0', '2.5', '2.8']);
+		expect(getLabels(chart.scales.r)).toEqual(['0.3', '0.5', '1.0', '1.5', '2.0', '2.5', '2.8']);
 	});
 
 	it('Should build labels using the user supplied callback', function() {
@@ -327,8 +327,8 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(getLabels(chart.scale)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
-		expect(chart.scale.pointLabels).toEqual(['label1', 'label2', 'label3', 'label4', 'label5']);
+		expect(getLabels(chart.scales.r)).toEqual(['0', '1', '2', '3', '4', '5', '6', '7', '8']);
+		expect(chart.scales.r.pointLabels).toEqual(['label1', 'label2', 'label3', 'label4', 'label5']);
 	});
 
 	it('Should build point labels using the user supplied callback', function() {
@@ -351,7 +351,7 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.pointLabels).toEqual(['0', '1', '2', '3', '4']);
+		expect(chart.scales.r.pointLabels).toEqual(['0', '1', '2', '3', '4']);
 	});
 
 	it('Should build point labels from falsy values', function() {
@@ -365,7 +365,7 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.pointLabels).toEqual([0, '', '', '', '', '']);
+		expect(chart.scales.r.pointLabels).toEqual([0, '', '', '', '', '']);
 	});
 
 	it('should correctly set the center point', function() {
@@ -388,9 +388,9 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.drawingArea).toBe(227);
-		expect(chart.scale.xCenter).toBe(256);
-		expect(chart.scale.yCenter).toBe(284);
+		expect(chart.scales.r.drawingArea).toBe(227);
+		expect(chart.scales.r.xCenter).toBe(256);
+		expect(chart.scales.r.yCenter).toBe(284);
 	});
 
 	it('should correctly get the label for a given data index', function() {
@@ -412,7 +412,7 @@ describe('Test the radial linear scale', function() {
 				}
 			}
 		});
-		expect(chart.scale.getLabelForValue(5)).toBe(5);
+		expect(chart.scales.r.getLabelForValue(5)).toBe(5);
 	});
 
 	it('should get the correct distance from the center point', function() {
@@ -435,18 +435,18 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.min)).toBe(0);
-		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.max)).toBe(227);
+		expect(chart.scales.r.getDistanceFromCenterForValue(chart.scales.r.min)).toBe(0);
+		expect(chart.scales.r.getDistanceFromCenterForValue(chart.scales.r.max)).toBe(227);
 
-		var position = chart.scale.getPointPositionForValue(1, 5);
+		var position = chart.scales.r.getPointPositionForValue(1, 5);
 		expect(position.x).toBeCloseToPixel(270);
 		expect(position.y).toBeCloseToPixel(278);
 
-		chart.scale.options.reverse = true;
+		chart.scales.r.options.reverse = true;
 		chart.update();
 
-		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.min)).toBe(227);
-		expect(chart.scale.getDistanceFromCenterForValue(chart.scale.max)).toBe(0);
+		expect(chart.scales.r.getDistanceFromCenterForValue(chart.scales.r.min)).toBe(227);
+		expect(chart.scales.r.getDistanceFromCenterForValue(chart.scales.r.max)).toBe(0);
 	});
 
 	it('should correctly get angles for all points', function() {
@@ -477,14 +477,14 @@ describe('Test the radial linear scale', function() {
 		var slice = 72; // (360 / 5)
 
 		for (var i = 0; i < 5; i++) {
-			expect(radToNearestDegree(chart.scale.getIndexAngle(i))).toBe(15 + (slice * i));
+			expect(radToNearestDegree(chart.scales.r.getIndexAngle(i))).toBe(15 + (slice * i));
 		}
 
 		chart.options.startAngle = 0;
 		chart.update();
 
 		for (var x = 0; x < 5; x++) {
-			expect(radToNearestDegree(chart.scale.getIndexAngle(x))).toBe((slice * x));
+			expect(radToNearestDegree(chart.scales.r.getIndexAngle(x))).toBe((slice * x));
 		}
 	});
 
@@ -511,7 +511,7 @@ describe('Test the radial linear scale', function() {
 			}
 		});
 
-		var scale = chart.scale;
+		var scale = chart.scales.r;
 
 		[{
 			startAngle: 30,

--- a/test/specs/scale.time.tests.js
+++ b/test/specs/scale.time.tests.js
@@ -13,13 +13,13 @@ describe('Time scale tests', function() {
 			data: data,
 			options: {
 				scales: {
-					xAxes: [options]
+					x: options
 				}
 			}
 		}, {canvas: {width: width, height: height}});
 
 
-		return chart.scales.xScale0;
+		return chart.scales.x;
 	}
 
 	function getLabels(scale) {
@@ -145,7 +145,7 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: [{
 							x: newDateFromRef(0),
 							y: 1
@@ -172,16 +172,15 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							position: 'bottom'
-						}],
+						},
 					}
 				}
 			}, {canvas: {width: 800, height: 200}});
 
-			var xScale = chart.scales.xScale0;
+			var xScale = chart.scales.x;
 			var ticks = getLabels(xScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -193,7 +192,7 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'tScale0',
+						xAxisID: 'x',
 						data: [{
 							t: newDateFromRef(0),
 							y: 1
@@ -220,16 +219,15 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'tScale0',
+						x: {
 							type: 'time',
 							position: 'bottom'
-						}],
+						},
 					}
 				}
 			}, {canvas: {width: 800, height: 200}});
 
-			var tScale = chart.scales.tScale0;
+			var tScale = chart.scales.x;
 			var ticks = getLabels(tScale);
 
 			// `bounds === 'data'`: first and last ticks removed since outside the data range
@@ -243,14 +241,13 @@ describe('Time scale tests', function() {
 			data: {
 				labels: ['foo', 'bar'],
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [0, 1]
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom',
 						time: {
@@ -265,13 +262,13 @@ describe('Time scale tests', function() {
 						ticks: {
 							source: 'labels'
 						}
-					}],
+					},
 				}
 			}
 		});
 
 		// Counts down because the lines are drawn top to bottom
-		var labels = getLabels(chart.scales.xScale0);
+		var labels = getLabels(chart.scales.x);
 
 		// Counts down because the lines are drawn top to bottom
 		expect(labels[0]).toBe('Jan 2');
@@ -322,25 +319,24 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: data
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						ticks: {
 							source: 'data',
 							autoSkip: true
 						}
-					}],
+					},
 				}
 			}
 		});
 
-		var scale = chart.scales.xScale0;
+		var scale = chart.scales.x;
 
 		expect(scale._unit).toEqual('month');
 	});
@@ -517,7 +513,7 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: []
 					}],
 					labels: [
@@ -532,16 +528,15 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
-							position: 'bottom',
-						}],
+							position: 'bottom'
+						},
 					}
 				}
 			});
 
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should be bounded by the nearest week beginnings', function() {
@@ -585,17 +580,16 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							bounds: 'ticks',
 							position: 'bottom'
-						}],
+						},
 					}
 				}
 			}, {canvas: {width: 800, height: 200}});
 
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should be bounded by nearest step\'s year start and end', function() {
@@ -641,27 +635,26 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [null, 10, 3]
 				}],
 				labels: ['2015-01-01T20:00:00', '2015-01-02T21:00:00', '2015-01-03T22:00:00', '2015-01-05T23:00:00', '2015-01-07T03:00', '2015-01-08T10:00', '2015-01-10T12:00'], // days
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom',
 						ticks: {
 							source: 'labels',
 							autoSkip: false
 						}
-					}],
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		var controller = chart.getDatasetMeta(0).controller;
 		expect(xScale.getLabelForValue(controller._getParsed(0)[xScale.id])).toBeTruthy();
 		expect(xScale.getLabelForValue(controller._getParsed(0)[xScale.id])).toBe('Jan 1, 2015, 8:00:00 pm');
@@ -674,15 +667,14 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: [0, 0]
 					}],
 					labels: ['2015-01-01T20:00:00', '2015-01-01T20:01:00']
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							time: {
 								displayFormats: {
@@ -694,11 +686,11 @@ describe('Time scale tests', function() {
 									return '<' + value + '>';
 								}
 							}
-						}]
+						}
 					}
 				}
 			});
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should get the correct labels for ticks', function() {
@@ -711,7 +703,7 @@ describe('Time scale tests', function() {
 
 		it('should update ticks.callback correctly', function() {
 			var chart = this.chart;
-			chart.options.scales.xAxes[0].ticks.callback = function(value) {
+			chart.options.scales.x.ticks.callback = function(value) {
 				return '{' + value + '}';
 			};
 			chart.update();
@@ -729,15 +721,14 @@ describe('Time scale tests', function() {
 				type: 'line',
 				data: {
 					datasets: [{
-						xAxisID: 'xScale0',
+						xAxisID: 'x',
 						data: [0, 0]
 					}],
 					labels: ['2015-01-01T20:00:00', '2015-01-01T20:01:00']
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'xScale0',
+						x: {
 							type: 'time',
 							ticks: {
 								callback: function(value) {
@@ -755,11 +746,11 @@ describe('Time scale tests', function() {
 									}
 								}
 							}
-						}]
+						}
 					}
 				}
 			});
-			this.scale = this.chart.scales.xScale0;
+			this.scale = this.chart.scales.x;
 		});
 
 		it('should get the correct labels for major and minor ticks', function() {
@@ -773,7 +764,7 @@ describe('Time scale tests', function() {
 
 		it('should only use ticks.minor callback if ticks.major.enabled is false', function() {
 			var chart = this.chart;
-			chart.options.scales.xAxes[0].ticks.major.enabled = false;
+			chart.options.scales.x.ticks.major.enabled = false;
 			chart.update();
 
 			var labels = getLabels(this.scale);
@@ -784,7 +775,7 @@ describe('Time scale tests', function() {
 
 		it('should use ticks.callback if ticks.major.callback is omitted', function() {
 			var chart = this.chart;
-			chart.options.scales.xAxes[0].ticks.major.callback = undefined;
+			chart.options.scales.x.ticks.major.callback = undefined;
 			chart.update();
 
 			var labels = getLabels(this.scale);
@@ -795,7 +786,7 @@ describe('Time scale tests', function() {
 
 		it('should use ticks.callback if ticks.minor.callback is omitted', function() {
 			var chart = this.chart;
-			chart.options.scales.xAxes[0].ticks.minor.callback = undefined;
+			chart.options.scales.x.ticks.minor.callback = undefined;
 			chart.update();
 
 			var labels = getLabels(this.scale);
@@ -811,22 +802,21 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [{t: '2015-01-01T20:00:00', y: 10}, {t: '2015-01-02T21:00:00', y: 3}]
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom'
-					}],
+					},
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		var controller = chart.getDatasetMeta(0).controller;
 		var value = controller._getParsed(0)[xScale.id];
 		expect(xScale.getLabelForValue(value)).toBeTruthy();
@@ -838,7 +828,7 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [
 						{t: +new Date('2018-01-08 05:14:23.234'), y: 10},
 						{t: +new Date('2018-01-09 06:17:43.426'), y: 3}
@@ -847,16 +837,15 @@ describe('Time scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						position: 'bottom'
-					}],
+					},
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		var controller = chart.getDatasetMeta(0).controller;
 		var label = xScale.getLabelForValue(controller._getParsed(0)[xScale.id]);
 		expect(label).toEqual('Jan 8, 2018, 5:14:23 am');
@@ -868,22 +857,21 @@ describe('Time scale tests', function() {
 			data: {
 				labels: ['2016-05-27'],
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: [5]
 				}]
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						display: true,
 						type: 'time'
-					}]
+					}
 				}
 			}
 		});
 
-		var xScale = chart.scales.xScale0;
+		var xScale = chart.scales.x;
 		var pixel = xScale.getPixelForValue(moment('2016-05-27').valueOf());
 
 		expect(xScale.getValueForPixel(pixel)).toEqual(moment(chart.data.labels[0]).valueOf());
@@ -899,13 +887,13 @@ describe('Time scale tests', function() {
 			},
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
 						ticks: {
 							min: moment().subtract(1, 'months'),
 							max: moment(),
 						}
-					}],
+					},
 				},
 				responsive: true,
 			},
@@ -914,8 +902,8 @@ describe('Time scale tests', function() {
 				style: 'display: none',
 			},
 		});
-		expect(chart.scales['y-axis-0'].width).toEqual(0);
-		expect(chart.scales['y-axis-0'].maxWidth).toEqual(0);
+		expect(chart.scales.y.width).toEqual(0);
+		expect(chart.scales.y.maxWidth).toEqual(0);
 		expect(chart.width).toEqual(0);
 	});
 
@@ -930,8 +918,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -939,7 +926,7 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}]
+							}
 						}
 					}
 				});
@@ -956,7 +943,7 @@ describe('Time scale tests', function() {
 			it ('should not add ticks for min and max if they extend the labels range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				options.max = '2051';
@@ -970,7 +957,7 @@ describe('Time scale tests', function() {
 			it ('should not duplicate ticks if min and max are the labels limits', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2017';
 				options.max = '2042';
@@ -995,7 +982,7 @@ describe('Time scale tests', function() {
 			it ('should correctly handle empty `data.labels` using `time.unit`', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.time.unit = 'year';
 				chart.data.labels = [];
@@ -1024,8 +1011,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1033,7 +1019,7 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'data'
 								}
-							}]
+							}
 						}
 					}
 				});
@@ -1050,7 +1036,7 @@ describe('Time scale tests', function() {
 			it ('should not add ticks for min and max if they extend the labels range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				options.max = '2051';
@@ -1064,7 +1050,7 @@ describe('Time scale tests', function() {
 			it ('should not duplicate ticks if min and max are the labels limits', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2017';
 				options.max = '2043';
@@ -1090,7 +1076,7 @@ describe('Time scale tests', function() {
 			it ('should correctly handle empty `data.labels` and hidden datasets using `time.unit`', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.time.unit = 'year';
 				chart.data.labels = [];
@@ -1116,8 +1102,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1126,10 +1111,10 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1149,7 +1134,7 @@ describe('Time scale tests', function() {
 			it ('should add a step before if scale.min is before the first data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				chart.update();
@@ -1163,7 +1148,7 @@ describe('Time scale tests', function() {
 			it ('should add a step after if scale.max is after the last data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.max = '2050';
 				chart.update();
@@ -1177,7 +1162,7 @@ describe('Time scale tests', function() {
 			it ('should add steps before and after if scale.min/max are outside the data range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				options.max = '2050';
@@ -1200,8 +1185,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1210,10 +1194,10 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1233,7 +1217,7 @@ describe('Time scale tests', function() {
 			it ('should take in account scale min and max if outside the ticks range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				options.max = '2050';
@@ -1262,18 +1246,17 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								bounds: 'data',
 								time: {
 									parser: 'MM/DD HH:mm',
 									unit: 'day'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1299,18 +1282,17 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								bounds: 'ticks',
 								time: {
 									parser: 'MM/DD HH:mm',
 									unit: 'day'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1341,8 +1323,7 @@ describe('Time scale tests', function() {
 							},
 							options: {
 								scales: {
-									xAxes: [{
-										id: 'x',
+									x: {
 										type: 'time',
 										bounds: bounds,
 										time: {
@@ -1352,10 +1333,10 @@ describe('Time scale tests', function() {
 										ticks: {
 											source: source
 										}
-									}],
-									yAxes: [{
+									},
+									y: {
 										display: false
-									}]
+									}
 								}
 							}
 						});
@@ -1364,7 +1345,7 @@ describe('Time scale tests', function() {
 					it ('should expand scale to the min/max range', function() {
 						var chart = this.chart;
 						var scale = chart.scales.x;
-						var options = chart.options.scales.xAxes[0];
+						var options = chart.options.scales.x;
 						var min = '02/19 07:00';
 						var max = '02/24 08:00';
 						var minMillis = +moment(min, 'MM/DD HH:mm');
@@ -1386,7 +1367,7 @@ describe('Time scale tests', function() {
 					it ('should shrink scale to the min/max range', function() {
 						var chart = this.chart;
 						var scale = chart.scales.x;
-						var options = chart.options.scales.xAxes[0];
+						var options = chart.options.scales.x;
 						var min = '02/21 07:00';
 						var max = '02/22 20:00';
 						var minMillis = +moment(min, 'MM/DD HH:mm');
@@ -1422,8 +1403,7 @@ describe('Time scale tests', function() {
 						},
 						options: {
 							scales: {
-								xAxes: [{
-									id: 'x',
+								x: {
 									type: 'time',
 									time: {
 										parser: 'YYYY'
@@ -1432,7 +1412,7 @@ describe('Time scale tests', function() {
 										source: source
 									},
 									distribution: distribution
-								}]
+								}
 							}
 						}
 					});
@@ -1448,7 +1428,7 @@ describe('Time scale tests', function() {
 				it ('should add offset from the edges if offset is true', function() {
 					var chart = this.chart;
 					var scale = chart.scales.x;
-					var options = chart.options.scales.xAxes[0];
+					var options = chart.options.scales.x;
 
 					options.offset = true;
 					chart.update();
@@ -1464,7 +1444,7 @@ describe('Time scale tests', function() {
 				it ('should not add offset if min and max extend the labels range', function() {
 					var chart = this.chart;
 					var scale = chart.scales.x;
-					var options = chart.options.scales.xAxes[0];
+					var options = chart.options.scales.x;
 
 					options.min = '2012';
 					options.max = '2051';
@@ -1489,7 +1469,7 @@ describe('Time scale tests', function() {
 						},
 						options: {
 							scales: {
-								xAxes: [{
+								x: {
 									id: 'x',
 									type: 'time',
 									time: {
@@ -1499,7 +1479,7 @@ describe('Time scale tests', function() {
 										source: source
 									},
 									distribution: distribution
-								}]
+								}
 							}
 						}
 					});
@@ -1508,7 +1488,7 @@ describe('Time scale tests', function() {
 				it ('should add offset if min and max extend the labels range and offset is true', function() {
 					var chart = this.chart;
 					var scale = chart.scales.x;
-					var options = chart.options.scales.xAxes[0];
+					var options = chart.options.scales.x;
 
 					options.min = '2012';
 					options.max = '2051';
@@ -1536,8 +1516,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								reverse: true,
 								time: {
@@ -1546,10 +1525,10 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels',
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1576,7 +1555,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the bars and add offsets if offset is true', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.offset = true;
 				chart.update();
@@ -1592,7 +1571,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the values for pixels if offset is true', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.offset = true;
 				chart.update();
@@ -1624,8 +1603,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1635,10 +1613,10 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1659,7 +1637,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should add a step before if scale.min is before the first data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				chart.update();
@@ -1674,7 +1652,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should add a step after if scale.max is after the last data', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.max = '2050';
 				chart.update();
@@ -1689,7 +1667,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should add steps before and after if scale.min/max are outside the data range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				options.max = '2050';
@@ -1712,8 +1690,7 @@ describe('Time scale tests', function() {
 					},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									parser: 'YYYY'
@@ -1723,10 +1700,10 @@ describe('Time scale tests', function() {
 								ticks: {
 									source: 'labels'
 								}
-							}],
-							yAxes: [{
+							},
+							y: {
 								display: false
-							}]
+							}
 						}
 					}
 				});
@@ -1747,7 +1724,7 @@ describe('Time scale tests', function() {
 			it ('should reverse the labels and should take in account scale min and max if outside the ticks range', function() {
 				var chart = this.chart;
 				var scale = chart.scales.x;
-				var options = chart.options.scales.xAxes[0];
+				var options = chart.options.scales.x;
 
 				options.min = '2012';
 				options.max = '2050';
@@ -1783,28 +1760,26 @@ describe('Time scale tests', function() {
 				},
 				options: {
 					scales: {
-						xAxes: [{
-							id: 'x',
+						x: {
 							type: 'time',
 							labels: ['2015', '2016', '2017'],
 							time: timeOpts
 						},
-						{
-							id: 'x2',
+						x2: {
 							type: 'time',
+							position: 'bottom',
 							time: timeOpts
-						}],
-						yAxes: [{
-							id: 'y',
+						},
+						y: {
 							type: 'time',
 							time: timeOpts
 						},
-						{
-							id: 'y2',
+						y2: {
+							position: 'left',
 							type: 'time',
 							labels: ['2005', '2006', '2007'],
 							time: timeOpts
-						}]
+						}
 					}
 				}
 			});
@@ -1828,14 +1803,13 @@ describe('Time scale tests', function() {
 			type: 'line',
 			data: {
 				datasets: [{
-					xAxisID: 'xScale0',
+					xAxisID: 'x',
 					data: data
 				}],
 			},
 			options: {
 				scales: {
-					xAxes: [{
-						id: 'xScale0',
+					x: {
 						type: 'time',
 						ticks: {
 							major: {
@@ -1844,12 +1818,12 @@ describe('Time scale tests', function() {
 							source: 'data',
 							autoSkip: true
 						}
-					}],
+					},
 				}
 			}
 		});
 
-		var scale = chart.scales.xScale0;
+		var scale = chart.scales.x;
 
 		var labels = scale.ticks.map(function(t) {
 			return t.label;
@@ -1870,10 +1844,9 @@ describe('Time scale tests', function() {
 					data: {},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time'
-							}]
+							}
 						}
 					}
 				});
@@ -1893,7 +1866,7 @@ describe('Time scale tests', function() {
 				};
 
 				expect(chart.scales.x.options.time.displayFormats).toEqual(expected);
-				expect(chart.options.scales.xAxes[0].time.displayFormats).toEqual(expected);
+				expect(chart.options.scales.x.time.displayFormats).toEqual(expected);
 			});
 
 			it('should merge user formats with adapter presets', function() {
@@ -1902,8 +1875,7 @@ describe('Time scale tests', function() {
 					data: {},
 					options: {
 						scales: {
-							xAxes: [{
-								id: 'x',
+							x: {
 								type: 'time',
 								time: {
 									displayFormats: {
@@ -1912,7 +1884,7 @@ describe('Time scale tests', function() {
 										month: 'bla'
 									}
 								}
-							}]
+							}
 						}
 					}
 				});
@@ -1932,7 +1904,7 @@ describe('Time scale tests', function() {
 				};
 
 				expect(chart.scales.x.options.time.displayFormats).toEqual(expected);
-				expect(chart.options.scales.xAxes[0].time.displayFormats).toEqual(expected);
+				expect(chart.options.scales.x.time.displayFormats).toEqual(expected);
 			});
 		});
 	});


### PR DESCRIPTION
* Convert axis options from arrays to objects

* Updated all chart type defaults
* Throw errors when axis type or position are not specified
* Avoid raising unnecessary errors when merging options into the default configs

* Fix additional tests

* Ensure scale defaults are set if type is not explicitly defined

* Another step

* Include `scale` as `firstIDs.r`

* update docs

* Update for buildOrUpdateScales

* Update migration guide

* Add test back

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
