### PR TITLE
Make the build reproducible (#6817)

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,7 +12,7 @@ const input = 'src/index.js';
 const banner = `/*!
  * Chart.js v${pkg.version}
  * ${pkg.homepage}
- * (c) ${new Date().getFullYear()} Chart.js Contributors
+ * (c) ${(new Date(process.env.SOURCE_DATE_EPOCH ? (process.env.SOURCE_DATE_EPOCH * 1000) : new Date().getTime())).getFullYear()} Chart.js Contributors
  * Released under the MIT License
  */`;
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0] we noticed that
Chart.js could not be built reproducibly.

This is because it was embedding another build date in a "banner"
comment. This patch uses the value from SOURCE_DATE_EPOCH [1] if
present.

This was originally filed in Debian as #946333 [2].

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/
 [2] https://bugs.debian.org/946333

Signed-off-by: Chris Lamb <lamby@debian.org>

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
