### PR TITLE
Minor type fixes (#8719)

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -2370,9 +2370,9 @@ export interface TooltipOptions<TType extends ChartType> extends CoreInteraction
   /**
    * Sort tooltip items.
    */
-  itemSort: (a: TooltipItem<ChartType>, b: TooltipItem<ChartType>) => number;
+  itemSort: (a: TooltipItem<ChartType>, b: TooltipItem<ChartType>, data: ChartData) => number;
 
-  filter: (e: TooltipItem<ChartType>) => boolean;
+  filter: (e: TooltipItem<ChartType>, index: number, array: TooltipItem<ChartType>[], data: ChartData) => boolean;
 
   /**
    * Background color of the tooltip.
@@ -3041,7 +3041,7 @@ export type RadialLinearScaleOptions = CoreScaleOptions & {
      * Padding of label backdrop.
      * @default 2
      */
-     backdropPadding: Scriptable<number | ChartArea, ScriptableScaleContext>;
+    backdropPadding: Scriptable<number | ChartArea, ScriptableScaleContext>;
 
     /**
      * if true, point labels are shown.
@@ -3060,9 +3060,8 @@ export type RadialLinearScaleOptions = CoreScaleOptions & {
 
     /**
      * Callback function to transform data labels to point labels. The default implementation simply returns the current string.
-     * @default true
      */
-    callback: (label: string) => string;
+    callback: (label: string, index: number) => string;
   };
 
   /**


### PR DESCRIPTION
* Update RadialLinearScaleOptions.pointLabels.callback type

The code passes `index` as the second parameter, and one of the tests uses this.  `@default true` doesn't seem to make sense.

* Add types for additional documented parameters in tooltip callbacks

<!--
Please consider the following before submitting a pull request:

Guidelines for contributing: https://github.com/chartjs/Chart.js/blob/master/docs/docs/developers/contributing.md

Example of changes on an interactive website such as the following:
- https://jsbin.com/
- https://jsfiddle.net/
- https://codepen.io/pen/
- Premade template: https://codepen.io/pen?template=JXVYzq
-->
